### PR TITLE
Switch to bn fork

### DIFF
--- a/precompiled/bn128/Cargo.toml
+++ b/precompiled/bn128/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/etclabscore/sputnikvm"
 [dependencies]
 evm = { version = "0.10", path = "../..", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
-bn-plus = { version = "0.4" }
+bn = { version = "0.4", git = "https://github.com/etclabscore/bn.git", rev = "a604e5da959e1878318c8eea5219d90d6a28f578", default-features = false }
 
 [features]
 default = ["std", "rust-secp256k1"]
 rlp = ["ethereum-bigint/rlp"]
 c-secp256k1 = ["evm/c-secp256k1"]
 rust-secp256k1 = ["evm/rust-secp256k1"]
-std = ["evm/std"]
+std = ["evm/std", "bn/std"]


### PR DESCRIPTION
Switching to bn fork with serializer patches to enable no-std builds.
Unlike the previous PR, this fixes the dependency on the git revision, not branch