### PR TITLE
feat: common code formatting rules with rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 
 rust:
   - stable
@@ -9,9 +10,13 @@ os:
   - linux
   - osx
 
+before_script:
+  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then rustup component add rustfmt; fi
+
 script:
   - cargo build --release --all --verbose
   - cargo test --release --all --verbose
+  - if [ "$TRAVIS_RUST_VERSION" == "stable" ]; then cargo fmt -- --check; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features --features rust-secp256k1; fi
 
 matrix:

--- a/FORMATTING.md
+++ b/FORMATTING.md
@@ -1,0 +1,88 @@
+### Formatting
+This repository incorporates a certain formatting style derived from the [rustfmt defaults](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md) with a few changes, which are:
+ - Maximum line width is 120 characters
+ - Newline separator style is always Unix (`\n` as opposed to Windows `\n\r`)
+ - `try!` macro would automatically convert into a `?` question-mark operator expression
+ 
+Any other configuration is the **stable** `rustfmt` default.
+
+#### Running the formatter
+`evm-rs` is a complex project with a lot of sub-crates, so `cargo fmt` should be invoked with an `--all` argument.
+```bash
+cargo fmt --all
+```
+More info can be found at the [project page](https://github.com/rust-lang/rustfmt)
+
+#### Manual formatting overrides
+The formatting constraint is checked within Travis CI and Jenkins continuous integration pipelines, hence any pull-request should be formatted before it may be merged.
+
+Though, as most of the tooling generally is, `rustfmt` isn’t perfect and sometimes one would requite to force the manual formatting, as, for instance, it’s required for the `Patch` interface in `evm-rs`
+##### Original code
+```rust
+pub struct EmbeddedAccountPatch;
+impl AccountPatch for EmbeddedAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+```
+##### `Rustfmt` formatted code
+```rust
+pub struct EmbeddedAccountPatch;
+impl AccountPatch for EmbeddedAccountPatch {
+    fn initial_nonce() -> U256 { 
+        U256::zero() 
+    }
+    fn initial_create_nonce() -> U256 { 
+        Self::initial_nonce() 
+    }
+    fn empty_considered_exists() -> bool { 
+        true 
+    }
+}
+```
+Depending on the case, the readability of the code may decrease, like here (IMHO) since the expanded function body brings none value. 
+While this would be possible to fix with **nightly** `rustfmt`, nightly version is still too unstable, so it’s encouraged to use manual formatting overrides where it is justified.
+##### Manual override
+```rust
+pub struct EmbeddedAccountPatch;
+#[rustfmt::skip]
+impl AccountPatch for EmbeddedAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+```
+#### Automation
+To ensure none commits are misformatted, it’s required to manually run rustfmt before commiting the code, though that might be irritating.
+Fortunately, formatting (and formatting checks) may be automated, and here are ways to do that:
+##### 1. Formatting on save
+Most of the editors have a feature of pre-save hooks that can execute arbitrary commands before persisting the file contents.
+* [Setup for JetBrains IDEs (Clion, Intellij Idea, …)](https://codurance.com/2017/11/26/rusting-IntelliJ/)
+* [Setup for VSCode](https://github.com/editor-rs/vscode-rust/blob/master/doc/format.md)
+
+If the editor doesn’t support the on-save hook, one could automate formatting through [cargo watch](https://github.com/passcod/cargo-watch):
+```bash
+cargo watch -s “cargo fmt --all”
+```
+##### 2. Git pre-commit hook
+Create a file `.git/hooks/pre-commit` with the following contents:
+```
+#!/bin/sh
+# Put in your Rust repository’s .git/hooks/pre-commit to ensure you never
+# breaks rustfmt. 
+#
+# WARNING: rustfmt is a fast moving target so ensure you have the version that
+# all contributors have.
+for FILE in `git diff --cached --name-only`; do
+    if [[ $FILE == *.rs ]] && ! rustfmt --check $FILE; then
+        echo “Commit rejected due to invalid formatting of \”$FILE\" file.”
+        exit 1
+    fi
+done
+```
+This hook will reject ill-formatted code before the commit.
+
+Synergy of these two automation techniques should allow one to ensure formatting correctness while not being forced to run `rustfmt` manually.
+
+

--- a/cli/src/bin/profiler.rs
+++ b/cli/src/bin/profiler.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, hash_map};
-use std::cmp::Ordering;
 use flame::Span;
+use std::cmp::Ordering;
+use std::collections::{hash_map, HashMap};
 
 pub struct Profiler {
     occurances: HashMap<String, (usize, f64)>,
@@ -20,23 +20,24 @@ impl Profiler {
         match self.occurances.entry(opcode) {
             hash_map::Entry::Occupied(mut entry) => {
                 let (occ, avg) = *entry.get();
-                let (nocc, navg) = (occ + 1, ((avg * (occ as f64)) + (span.delta as f64)) / ((occ + 1) as f64));
+                let (nocc, navg) = (
+                    occ + 1,
+                    ((avg * (occ as f64)) + (span.delta as f64)) / ((occ + 1) as f64),
+                );
                 entry.insert((nocc, navg));
-            },
+            }
             hash_map::Entry::Vacant(entry) => {
                 entry.insert((1, span.delta as f64));
-            },
+            }
         }
     }
 
     pub fn print_stats(&self) {
         println!("--- Profiler Stats ---");
         let mut occs: Vec<_> = self.occurances.iter().collect();
-        occs.sort_by(|&(_k1, v1), &(_k2, v2)| {
-            match v1.1.partial_cmp(&v2.1) {
-                Some(val) => val,
-                None => Ordering::Equal,
-            }
+        occs.sort_by(|&(_k1, v1), &(_k2, v2)| match v1.1.partial_cmp(&v2.1) {
+            Some(val) => val,
+            None => Ordering::Equal,
         });
         occs.reverse();
         for occ in occs {

--- a/gethrpc/src/lib.rs
+++ b/gethrpc/src/lib.rs
@@ -1,8 +1,8 @@
 mod record;
-pub use self::record::{RecordGethRPCClient, CachedGethRPCClient};
+pub use self::record::{CachedGethRPCClient, RecordGethRPCClient};
 
-use serde::{Serialize, Deserialize};
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 struct RPCRequest {
@@ -179,17 +179,11 @@ pub trait GethRPCClient {
     }
 
     fn account_exist(&mut self, address: &str, number: usize) -> bool {
-        self.rpc_object_request::<(String, usize), bool>(
-            "debug_accountExist",
-            (address.to_string(), number),
-        )
+        self.rpc_object_request::<(String, usize), bool>("debug_accountExist", (address.to_string(), number))
     }
 
     fn get_balance(&mut self, address: &str, number: &str) -> String {
-        self.rpc_request::<String>(
-            "eth_getBalance",
-            vec![address.to_string(), number.to_string()],
-        )
+        self.rpc_request::<String>("eth_getBalance", vec![address.to_string(), number.to_string()])
     }
 
     fn get_storage_at(&mut self, address: &str, index: &str, number: &str) -> String {
@@ -200,10 +194,7 @@ pub trait GethRPCClient {
     }
 
     fn get_transaction_count(&mut self, address: &str, number: &str) -> String {
-        self.rpc_request::<String>(
-            "eth_getTransactionCount",
-            vec![address.to_string(), number.to_string()],
-        )
+        self.rpc_request::<String>("eth_getTransactionCount", vec![address.to_string(), number.to_string()])
     }
 
     fn get_block_transaction_count_by_hash(&mut self, hash: &str) -> String {
@@ -211,10 +202,7 @@ pub trait GethRPCClient {
     }
 
     fn get_block_transaction_count_by_number(&mut self, number: &str) -> String {
-        self.rpc_request::<String>(
-            "eth_getBlockTransactionCountByNumber",
-            vec![number.to_string()],
-        )
+        self.rpc_request::<String>("eth_getBlockTransactionCountByNumber", vec![number.to_string()])
     }
 
     fn get_uncle_count_by_block_hash(&mut self, hash: &str) -> String {
@@ -234,46 +222,29 @@ pub trait GethRPCClient {
     }
 
     fn call(&mut self, transaction: RPCCall, number: &str) -> String {
-        self.rpc_object_request::<(RPCCall, String), String>(
-            "eth_call",
-            (transaction, number.to_string()),
-        )
+        self.rpc_object_request::<(RPCCall, String), String>("eth_call", (transaction, number.to_string()))
     }
 
     fn get_block_by_hash(&mut self, hash: &str) -> Option<RPCBlock> {
-        self.rpc_object_request::<(String, bool), Option<RPCBlock>>(
-            "eth_getBlockByHash",
-            (hash.to_string(), false),
-        )
+        self.rpc_object_request::<(String, bool), Option<RPCBlock>>("eth_getBlockByHash", (hash.to_string(), false))
     }
 
     fn get_block_by_number(&mut self, number: &str) -> Option<RPCBlock> {
-        self.rpc_object_request::<(String, bool), Option<RPCBlock>>(
-            "eth_getBlockByNumber",
-            (number.to_string(), false),
-        )
+        self.rpc_object_request::<(String, bool), Option<RPCBlock>>("eth_getBlockByNumber", (number.to_string(), false))
     }
 
     fn get_transaction_by_hash(&mut self, hash: &str) -> Option<RPCTransaction> {
         self.rpc_request::<Option<RPCTransaction>>("eth_getTransactionByHash", vec![hash.to_string()])
     }
 
-    fn get_transaction_by_block_hash_and_index(
-        &mut self,
-        hash: &str,
-        index: &str,
-    ) -> Option<RPCTransaction> {
+    fn get_transaction_by_block_hash_and_index(&mut self, hash: &str, index: &str) -> Option<RPCTransaction> {
         self.rpc_request::<Option<RPCTransaction>>(
             "eth_getTransactionByBlockHashAndIndex",
             vec![hash.to_string(), index.to_string()],
         )
     }
 
-    fn get_transaction_by_block_number_and_index(
-        &mut self,
-        number: &str,
-        index: &str,
-    ) -> Option<RPCTransaction> {
+    fn get_transaction_by_block_number_and_index(&mut self, number: &str, index: &str) -> Option<RPCTransaction> {
         self.rpc_request::<Option<RPCTransaction>>(
             "eth_getTransactionByBlockNumberAndIndex",
             vec![number.to_string(), index.to_string()],
@@ -281,10 +252,7 @@ pub trait GethRPCClient {
     }
 
     fn get_transaction_receipt(&mut self, hash: &str) -> Option<RPCTransactionReceipt> {
-        self.rpc_request::<Option<RPCTransactionReceipt>>(
-            "eth_getTransactionReceipt",
-            vec![hash.to_string()],
-        )
+        self.rpc_request::<Option<RPCTransactionReceipt>>("eth_getTransactionReceipt", vec![hash.to_string()])
     }
 
     fn get_uncle_by_block_hash_and_index(&mut self, hash: &str, index: &str) -> Option<RPCBlock> {
@@ -332,10 +300,7 @@ impl GethRPCClient for NormalGethRPCClient {
         };
         self.free_id = self.free_id + 1;
 
-        let mut response = self.http.post(&self.endpoint)
-            .json(&request)
-            .send()
-            .unwrap();
+        let mut response = self.http.post(&self.endpoint).json(&request).send().unwrap();
 
         let response: RPCObjectResponse<Res> = response.json().unwrap();
 

--- a/gethrpc/src/record.rs
+++ b/gethrpc/src/record.rs
@@ -1,8 +1,8 @@
 use super::{GethRPCClient, RPCObjectRequest, RPCObjectResponse};
 
-use serde::{Serialize, Deserialize};
-use serde_json;
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json;
 
 #[derive(Serialize, Deserialize)]
 struct Record {
@@ -48,14 +48,10 @@ impl GethRPCClient for RecordGethRPCClient {
         };
         self.free_id = self.free_id + 1;
 
-        let mut response = self.http.post(&self.endpoint)
-            .json(&request)
-            .send()
-            .unwrap();
+        let mut response = self.http.post(&self.endpoint).json(&request).send().unwrap();
 
         let response_value: serde_json::Value = response.json().unwrap();
-        let response: RPCObjectResponse<Res> = serde_json::from_value(response_value.clone())
-            .unwrap();
+        let response: RPCObjectResponse<Res> = serde_json::from_value(response_value.clone()).unwrap();
 
         self.records.push(Record {
             method: method.to_string(),
@@ -73,7 +69,9 @@ pub struct CachedGethRPCClient {
 
 impl CachedGethRPCClient {
     pub fn from_value(value: serde_json::Value) -> Self {
-        CachedGethRPCClient { records: serde_json::from_value(value).unwrap() }
+        CachedGethRPCClient {
+            records: serde_json::from_value(value).unwrap(),
+        }
     }
 }
 
@@ -87,8 +85,7 @@ impl GethRPCClient for CachedGethRPCClient {
 
         for record in &self.records {
             if &record.method == method && record.request == request_value {
-                let response: RPCObjectResponse<Res> =
-                    serde_json::from_value(record.response.clone()).unwrap();
+                let response: RPCObjectResponse<Res> = serde_json::from_value(record.response.clone()).unwrap();
                 return response.result;
             }
         }

--- a/jsontests/jsontests-derive/src/attr.rs
+++ b/jsontests/jsontests-derive/src/attr.rs
@@ -1,8 +1,8 @@
 use failure::Error;
 
 use syn;
-use syn::Lit::Str;
 use syn::Ident;
+use syn::Lit::Str;
 use syn::MetaItem;
 
 #[derive(Default)]
@@ -22,7 +22,6 @@ pub struct ExternalRef {
     pub name: Ident,
 }
 
-
 impl Default for ExternalRef {
     fn default() -> Self {
         ExternalRef {
@@ -37,48 +36,63 @@ impl From<String> for ExternalRef {
         let name = path.rsplit(':').next().unwrap().to_owned();
         ExternalRef {
             path: Ident::from(path),
-            name: Ident::from(name)
+            name: Ident::from(name),
         }
     }
 }
 
 pub fn extract_attrs(ast: &syn::DeriveInput) -> Result<Config, Error> {
     const ERROR_MSG: &str = "expected 2 attributes and 3 optional\n\n\
-                #[derive(JsonTests)]\n\
-                #[directory = \"../tests/testset\"]\n\
-                #[test_with = \"test::test_function\"]\n\
-                #[bench_wuth = \"test::bench_function\"] (Optional)\n\
-                #[patch = \"CustomTestPatch\" (Optional)\n\
-                #[skip] (Optional)\n\
-                #[should_panic] (Optional)\n\
-                struct TestSet;";
+                             #[derive(JsonTests)]\n\
+                             #[directory = \"../tests/testset\"]\n\
+                             #[test_with = \"test::test_function\"]\n\
+                             #[bench_wuth = \"test::bench_function\"] (Optional)\n\
+                             #[patch = \"CustomTestPatch\" (Optional)\n\
+                             #[skip] (Optional)\n\
+                             #[should_panic] (Optional)\n\
+                             struct TestSet;";
 
     if ast.attrs.len() < 2 || ast.attrs.len() > 6 {
-        return Err(failure::err_msg(ERROR_MSG))
+        return Err(failure::err_msg(ERROR_MSG));
     }
 
-    let config = ast.attrs.iter().fold(Config::default(), |config, attr| {
-        match attr.value {
-            MetaItem::NameValue(ref ident, Str(ref value, _)) => {
-                match ident.as_ref() {
-                    "directory" => Config { directory: value.clone(), ..config },
-                    "test_with" => Config { test_with: ExternalRef::from(value.clone()), ..config },
-                    "bench_with" => Config { bench_with: Some(ExternalRef::from(value.clone())), ..config },
-                    "criterion_config" => Config { criterion_config: Some(ExternalRef::from(value.clone())), ..config },
-                    "patch" => Config { patch: Some(ExternalRef::from(value.clone())), ..config },
-                    _ => panic!("{}", ERROR_MSG),
-                }
+    let config = ast
+        .attrs
+        .iter()
+        .fold(Config::default(), |config, attr| match attr.value {
+            MetaItem::NameValue(ref ident, Str(ref value, _)) => match ident.as_ref() {
+                "directory" => Config {
+                    directory: value.clone(),
+                    ..config
+                },
+                "test_with" => Config {
+                    test_with: ExternalRef::from(value.clone()),
+                    ..config
+                },
+                "bench_with" => Config {
+                    bench_with: Some(ExternalRef::from(value.clone())),
+                    ..config
+                },
+                "criterion_config" => Config {
+                    criterion_config: Some(ExternalRef::from(value.clone())),
+                    ..config
+                },
+                "patch" => Config {
+                    patch: Some(ExternalRef::from(value.clone())),
+                    ..config
+                },
+                _ => panic!("{}", ERROR_MSG),
             },
-            MetaItem::Word(ref ident) => {
-                match ident.as_ref() {
-                    "skip" => Config { skip: true, ..config },
-                    "should_panic" => Config { should_panic: true, ..config },
-                    _ => panic!("{}", ERROR_MSG),
-                }
-            }
-            _ => panic!("{}", ERROR_MSG)
-        }
-    });
+            MetaItem::Word(ref ident) => match ident.as_ref() {
+                "skip" => Config { skip: true, ..config },
+                "should_panic" => Config {
+                    should_panic: true,
+                    ..config
+                },
+                _ => panic!("{}", ERROR_MSG),
+            },
+            _ => panic!("{}", ERROR_MSG),
+        });
 
     // Check for incompatible options
     if config.should_panic && config.bench_with.is_some() {

--- a/jsontests/jsontests-derive/src/util.rs
+++ b/jsontests/jsontests-derive/src/util.rs
@@ -1,5 +1,5 @@
-use syn::Ident;
 use quote;
+use syn::Ident;
 
 use crate::attr::Config;
 
@@ -18,8 +18,7 @@ pub fn open_directory_module(config: &Config, tokens: &mut quote::Tokens) -> Str
 
 pub fn open_file_module(filepath: &str, tokens: &mut quote::Tokens) -> String {
     // get file name without extension
-    let filename = filepath.rsplit('/').next().unwrap()
-        .split('.').next().unwrap();
+    let filename = filepath.rsplit('/').next().unwrap().split('.').next().unwrap();
     // create identifier
     let filename = sanitize_ident(filename);
     let filename_ident = Ident::from(filename.as_ref());
@@ -46,12 +45,16 @@ pub fn sanitize_ident(ident: &str) -> String {
     // replace empty ident
     let ident = if ident.is_empty() {
         String::from("unnamed")
-    } else { ident.to_string() };
+    } else {
+        ident.to_string()
+    };
 
     // prepend alphabetic character if token starts with non-alphabetic character
     let ident = if ident.chars().nth(0).map(|c| !c.is_alphabetic()).unwrap_or(true) {
         format!("x_{}", ident)
-    } else { ident };
+    } else {
+        ident
+    };
 
     // replace special characters with _
     replace_chars(&ident, "!@#$%^&*-+=/<>;\'\"()`~", "_")

--- a/jsontests/src/blockchain.rs
+++ b/jsontests/src/blockchain.rs
@@ -1,15 +1,14 @@
-use bigint::{Gas, M256, U256, H256, Address};
+use bigint::{Address, Gas, H256, M256, U256};
+use evm::{AccountChange, AccountCommitment, Context, HeaderParams, Log};
 use hexutil::*;
-use evm::{Log, Context,
-          AccountChange, AccountCommitment,
-          HeaderParams};
-use serde_json::Value;
-use std::collections::HashMap;
-use std::str::FromStr;
-use std::rc::Rc;
+
 use rlp;
-use sha3::Keccak256;
+use serde_json::Value;
 use sha3::Digest;
+use sha3::Keccak256;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::str::FromStr;
 
 use crate::read_u256;
 
@@ -50,7 +49,7 @@ impl JSONBlock {
             address,
             balance,
             code: Rc::new(code.into()),
-            nonce
+            nonce,
         }
     }
 
@@ -62,11 +61,7 @@ impl JSONBlock {
             None => M256::zero(),
         };
 
-        AccountCommitment::Storage {
-            address,
-            index,
-            value,
-        }
+        AccountCommitment::Storage { address, index, value }
     }
 
     pub fn request_account_code(&self, address: Address) -> AccountCommitment {
@@ -96,25 +91,30 @@ impl JSONBlock {
                     self.storages.get_mut(&address).unwrap().insert(key, value);
                 }
                 self.set_account_nonce(address, nonce);
-            },
+            }
             AccountChange::Create {
-                address, balance, storage, code, nonce, ..
+                address,
+                balance,
+                storage,
+                code,
+                nonce,
+                ..
             } => {
                 self.set_balance(address, balance);
                 self.set_account_code(address, code.as_slice());
                 self.storages.insert(address, storage.into());
                 self.set_account_nonce(address, nonce);
-            },
+            }
             AccountChange::Nonexist(address) => {
                 self.set_balance(address, U256::zero());
                 self.set_account_code(address, &[]);
                 self.storages.insert(address, HashMap::new());
                 self.set_account_nonce(address, U256::zero());
-            },
+            }
             AccountChange::IncreaseBalance(address, topup) => {
                 let balance = self.balance(address);
                 self.set_balance(address, balance + topup);
-            },
+            }
         }
     }
 
@@ -173,12 +173,10 @@ impl JSONBlock {
     pub fn account_storage(&self, address: Address, index: U256) -> M256 {
         match self.storages.get(&address) {
             None => M256::zero(),
-            Some(ref ve) => {
-                match ve.get(&index) {
-                    Some(&v) => v,
-                    None => M256::zero()
-                }
-            }
+            Some(ref ve) => match ve.get(&index) {
+                Some(&v) => v,
+                None => M256::zero(),
+            },
         }
     }
 

--- a/jsontests/src/util.rs
+++ b/jsontests/src/util.rs
@@ -1,11 +1,8 @@
-use serde_json::Value;
-use serde_json as json;
 use evm::Patch;
+use serde_json as json;
+use serde_json::Value;
 
-use crate::{
-    test_transaction,
-    bench_transaction
-};
+use crate::{bench_transaction, test_transaction};
 
 pub fn run_test<P: Patch>(name: &str, test: &str) {
     let test: Value = json::from_str(test).unwrap();

--- a/jsontests/tests/eiptests.rs
+++ b/jsontests/tests/eiptests.rs
@@ -38,6 +38,8 @@ struct EIP1014;
 struct EIP1283;
 
 struct EIP1283Patch;
+
+#[rustfmt::skip]
 impl Patch for EIP1283Patch {
     type Account = EmbeddedAccountPatch;
 

--- a/jsontests/tests/harness.rs
+++ b/jsontests/tests/harness.rs
@@ -3,8 +3,8 @@
 
 #[macro_use]
 extern crate jsontests_derive;
-extern crate jsontests;
 extern crate evm;
+extern crate jsontests;
 
 #[derive(JsonTests)]
 #[directory = "jsontests/res/files/HarnessCorrectnessTests"]

--- a/jsontests/tests/inputlimits.rs
+++ b/jsontests/tests/inputlimits.rs
@@ -1,18 +1,19 @@
 #![allow(non_snake_case)]
 
+extern crate evm;
 extern crate jsontests;
 extern crate serde_json;
-extern crate evm;
 
-use serde_json::Value;
 use jsontests::test_transaction;
+use serde_json::Value;
 
 // Log format is broken for input limits tests
 
 #[test]
 #[ignore]
 fn inputLimitsLight() {
-    let TESTS: Value = serde_json::from_str(include_str!("../res/files/vmInputLimitsLight/vmInputLimitsLight.json")).unwrap();
+    let TESTS: Value =
+        serde_json::from_str(include_str!("../res/files/vmInputLimitsLight/vmInputLimitsLight.json")).unwrap();
     for (name, value) in TESTS.as_object().unwrap().iter() {
         print!("\t{} ... ", name);
         match test_transaction::<evm::VMTestPatch>(name, value, true) {
@@ -34,4 +35,3 @@ fn inputLimits() {
         }
     }
 }
-

--- a/jsontests/tests/vmtests.rs
+++ b/jsontests/tests/vmtests.rs
@@ -4,8 +4,8 @@
 
 #[macro_use]
 extern crate jsontests_derive;
-extern crate jsontests;
 extern crate evm;
+extern crate jsontests;
 
 #[cfg(feature = "bench")]
 extern crate test;

--- a/network/classic/src/lib.rs
+++ b/network/classic/src/lib.rs
@@ -1,12 +1,15 @@
-use std::marker::PhantomData;
-use bigint::{Gas, U256, H160, Address};
-use evm::{Precompiled, AccountPatch, Patch,
-          ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
-use evm_precompiled_modexp::MODEXP_PRECOMPILED;
+use bigint::{Address, Gas, H160, U256};
+use evm::{
+    AccountPatch, Patch, Precompiled, ECREC_PRECOMPILED, ID_PRECOMPILED, RIP160_PRECOMPILED, SHA256_PRECOMPILED,
+};
 use evm_precompiled_bn128::{BN128_ADD_PRECOMPILED, BN128_MUL_PRECOMPILED, BN128_PAIRING_PRECOMPILED};
+use evm_precompiled_modexp::MODEXP_PRECOMPILED;
+use std::marker::PhantomData;
 
 /// Mainnet account patch
 pub struct MainnetAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for MainnetAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
@@ -14,12 +17,15 @@ impl AccountPatch for MainnetAccountPatch {
 }
 
 pub struct MordenAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for MordenAccountPatch {
     fn initial_nonce() -> U256 { U256::from(1048576) }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
     fn empty_considered_exists() -> bool { true }
 }
 
+#[rustfmt::skip]
 pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -35,6 +41,7 @@ pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompi
      &ID_PRECOMPILED),
 ];
 
+#[rustfmt::skip]
 pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 8] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -66,6 +73,8 @@ pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pr
 pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
 pub type MordenFrontierPatch = FrontierPatch<MordenAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for FrontierPatch<A> {
     type Account = A;
 
@@ -99,6 +108,8 @@ impl<A: AccountPatch> Patch for FrontierPatch<A> {
 pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
 pub type MordenHomesteadPatch = HomesteadPatch<MordenAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for HomesteadPatch<A> {
     type Account = A;
 
@@ -132,6 +143,8 @@ impl<A: AccountPatch> Patch for HomesteadPatch<A> {
 pub struct EIP150Patch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetEIP150Patch = EIP150Patch<MainnetAccountPatch>;
 pub type MordenEIP150Patch = EIP150Patch<MordenAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for EIP150Patch<A> {
     type Account = A;
 
@@ -165,6 +178,8 @@ impl<A: AccountPatch> Patch for EIP150Patch<A> {
 pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
 pub type MordenEIP160Patch = EIP160Patch<MordenAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for EIP160Patch<A> {
     type Account = A;
 
@@ -198,6 +213,8 @@ impl<A: AccountPatch> Patch for EIP160Patch<A> {
 pub struct ByzantiumPatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetByzantiumPatch = ByzantiumPatch<MainnetAccountPatch>;
 pub type MordenByzantiumPatch = ByzantiumPatch<MordenAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for ByzantiumPatch<A> {
     type Account = A;
 
@@ -227,11 +244,12 @@ impl<A: AccountPatch> Patch for ByzantiumPatch<A> {
         &BYZANTIUM_PRECOMPILEDS }
 }
 
-
 /// Constantinople patch (includes Byzantium changes)
 pub struct ConstantinoplePatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetConstantinoplePatch = ConstantinoplePatch<MainnetAccountPatch>;
 pub type MordenConstantinoplePatch = ConstantinoplePatch<MordenAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for ConstantinoplePatch<A> {
     type Account = A;
 

--- a/network/ellaism/src/lib.rs
+++ b/network/ellaism/src/lib.rs
@@ -1,8 +1,10 @@
+use bigint::{Address, Gas, H160, U256};
+use evm::{
+    AccountPatch, Patch, Precompiled, ECREC_PRECOMPILED, ID_PRECOMPILED, RIP160_PRECOMPILED, SHA256_PRECOMPILED,
+};
 use std::marker::PhantomData;
-use bigint::{Gas, U256, H160, Address};
-use evm::{Precompiled, AccountPatch, Patch,
-          ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
 
+#[rustfmt::skip]
 pub static ELLA_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -20,6 +22,8 @@ pub static ELLA_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precomp
 
 /// Mainnet account patch
 pub struct MainnetAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for MainnetAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
@@ -29,6 +33,8 @@ impl AccountPatch for MainnetAccountPatch {
 /// EIP160 patch.
 pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for EIP160Patch<A> {
     type Account = A;
 

--- a/network/expanse/src/lib.rs
+++ b/network/expanse/src/lib.rs
@@ -1,9 +1,11 @@
-use bigint::{Gas, U256, H160, Address};
-use evm::{Precompiled, AccountPatch, Patch,
-          ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
-use evm_precompiled_modexp::MODEXP_PRECOMPILED;
+use bigint::{Address, Gas, H160, U256};
+use evm::{
+    AccountPatch, Patch, Precompiled, ECREC_PRECOMPILED, ID_PRECOMPILED, RIP160_PRECOMPILED, SHA256_PRECOMPILED,
+};
 use evm_precompiled_bn128::{BN128_ADD_PRECOMPILED, BN128_MUL_PRECOMPILED, BN128_PAIRING_PRECOMPILED};
+use evm_precompiled_modexp::MODEXP_PRECOMPILED;
 
+#[rustfmt::skip]
 pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -19,6 +21,7 @@ pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pre
      &ID_PRECOMPILED),
 ];
 
+#[rustfmt::skip]
 pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 8] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -47,6 +50,8 @@ pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pr
 ];
 
 pub struct FrontierAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for FrontierAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
@@ -54,6 +59,8 @@ impl AccountPatch for FrontierAccountPatch {
 }
 
 pub struct StateClearingAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for StateClearingAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::from(1) }
@@ -62,6 +69,8 @@ impl AccountPatch for StateClearingAccountPatch {
 
 /// Frontier patch.
 pub struct FrontierPatch;
+
+#[rustfmt::skip]
 impl Patch for FrontierPatch {
     type Account = FrontierAccountPatch;
 
@@ -93,6 +102,8 @@ impl Patch for FrontierPatch {
 
 /// Homestead patch.
 pub struct HomesteadPatch;
+
+#[rustfmt::skip]
 impl Patch for HomesteadPatch {
     type Account = FrontierAccountPatch;
 
@@ -124,6 +135,8 @@ impl Patch for HomesteadPatch {
 
 /// Spurious Dragon patch.
 pub struct SpuriousDragonPatch;
+
+#[rustfmt::skip]
 impl Patch for SpuriousDragonPatch {
     type Account = StateClearingAccountPatch;
 
@@ -155,6 +168,8 @@ impl Patch for SpuriousDragonPatch {
 
 /// Spurious Dragon patch.
 pub struct ByzantiumPatch;
+
+#[rustfmt::skip]
 impl Patch for ByzantiumPatch {
     type Account = StateClearingAccountPatch;
 

--- a/network/foundation/src/lib.rs
+++ b/network/foundation/src/lib.rs
@@ -1,9 +1,11 @@
-use bigint::{Gas, U256, H160, Address};
-use evm::{Precompiled, AccountPatch, Patch,
-          ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
-use evm_precompiled_modexp::MODEXP_PRECOMPILED;
+use bigint::{Address, Gas, H160, U256};
+use evm::{
+    AccountPatch, Patch, Precompiled, ECREC_PRECOMPILED, ID_PRECOMPILED, RIP160_PRECOMPILED, SHA256_PRECOMPILED,
+};
 use evm_precompiled_bn128::{BN128_ADD_PRECOMPILED, BN128_MUL_PRECOMPILED, BN128_PAIRING_PRECOMPILED};
+use evm_precompiled_modexp::MODEXP_PRECOMPILED;
 
+#[rustfmt::skip]
 pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -19,6 +21,7 @@ pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pre
      &ID_PRECOMPILED),
 ];
 
+#[rustfmt::skip]
 pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 8] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -47,6 +50,8 @@ pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pr
 ];
 
 pub struct FrontierAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for FrontierAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
@@ -54,6 +59,8 @@ impl AccountPatch for FrontierAccountPatch {
 }
 
 pub struct StateClearingAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for StateClearingAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::from(1) }
@@ -62,6 +69,8 @@ impl AccountPatch for StateClearingAccountPatch {
 
 /// Frontier patch.
 pub struct FrontierPatch;
+
+#[rustfmt::skip]
 impl Patch for FrontierPatch {
     type Account = FrontierAccountPatch;
 
@@ -93,6 +102,8 @@ impl Patch for FrontierPatch {
 
 /// Homestead patch.
 pub struct HomesteadPatch;
+
+#[rustfmt::skip]
 impl Patch for HomesteadPatch {
     type Account = FrontierAccountPatch;
 
@@ -124,6 +135,8 @@ impl Patch for HomesteadPatch {
 
 /// EIP150 patch.
 pub struct EIP150Patch;
+
+#[rustfmt::skip]
 impl Patch for EIP150Patch {
     type Account = FrontierAccountPatch;
 
@@ -155,6 +168,8 @@ impl Patch for EIP150Patch {
 
 /// Spurious Dragon patch.
 pub struct SpuriousDragonPatch;
+
+#[rustfmt::skip]
 impl Patch for SpuriousDragonPatch {
     type Account = StateClearingAccountPatch;
 
@@ -186,6 +201,8 @@ impl Patch for SpuriousDragonPatch {
 
 /// Spurious Dragon patch.
 pub struct ByzantiumPatch;
+
+#[rustfmt::skip]
 impl Patch for ByzantiumPatch {
     type Account = StateClearingAccountPatch;
 

--- a/network/musicoin/src/lib.rs
+++ b/network/musicoin/src/lib.rs
@@ -1,16 +1,20 @@
+use bigint::{Address, Gas, H160, U256};
+use evm::{
+    AccountPatch, Patch, Precompiled, ECREC_PRECOMPILED, ID_PRECOMPILED, RIP160_PRECOMPILED, SHA256_PRECOMPILED,
+};
 use std::marker::PhantomData;
-use bigint::{Gas, U256, H160, Address};
-use evm::{Precompiled, AccountPatch, Patch,
-          ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
 
 /// Mainnet account patch
 pub struct MainnetAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for MainnetAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
     fn empty_considered_exists() -> bool { true }
 }
 
+#[rustfmt::skip]
 pub static MUSIC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -29,6 +33,8 @@ pub static MUSIC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precom
 /// Frontier patch.
 pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for FrontierPatch<A> {
     type Account = A;
 
@@ -61,6 +67,8 @@ impl<A: AccountPatch> Patch for FrontierPatch<A> {
 /// Homestead patch.
 pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
+
+#[rustfmt::skip]
 impl<A: AccountPatch> Patch for HomesteadPatch<A> {
     type Account = A;
 

--- a/network/ubiq/src/lib.rs
+++ b/network/ubiq/src/lib.rs
@@ -1,7 +1,9 @@
-use bigint::{Gas, U256, H160, Address};
-use evm::{Precompiled, AccountPatch, Patch,
-          ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+use bigint::{Address, Gas, H160, U256};
+use evm::{
+    AccountPatch, Patch, Precompiled, ECREC_PRECOMPILED, ID_PRECOMPILED, RIP160_PRECOMPILED, SHA256_PRECOMPILED,
+};
 
+#[rustfmt::skip]
 pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -18,6 +20,8 @@ pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pre
 ];
 
 pub struct StateClearingAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for StateClearingAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::from(1) }
@@ -26,6 +30,8 @@ impl AccountPatch for StateClearingAccountPatch {
 
 /// Spurious Dragon patch.
 pub struct SpuriousDragonPatch;
+
+#[rustfmt::skip]
 impl Patch for SpuriousDragonPatch {
     type Account = StateClearingAccountPatch;
 

--- a/precompiled/bn128/src/lib.rs
+++ b/precompiled/bn128/src/lib.rs
@@ -1,15 +1,15 @@
-use std::rc::Rc;
 use bigint::{Gas, U256};
+use std::rc::Rc;
 
-use evm::Precompiled;
 use evm::errors::{OnChainError, RuntimeError};
+use evm::Precompiled;
 
 pub static BN128_ADD_PRECOMPILED: Bn128AddPrecompiled = Bn128AddPrecompiled;
 
 pub struct Bn128AddPrecompiled;
 impl Precompiled for Bn128AddPrecompiled {
     fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
-        use bn::{G1, AffineG1, Fq, Group};
+        use bn::{AffineG1, Fq, Group, G1};
 
         let gas = Gas::from(500usize);
         if gas > gas_limit {
@@ -22,24 +22,24 @@ impl Precompiled for Bn128AddPrecompiled {
             data.push(0);
         }
 
-        let px = Fq::from_slice(&data[0..32])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-        let py = Fq::from_slice(&data[32..64])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-        let qx = Fq::from_slice(&data[64..96])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-        let qy = Fq::from_slice(&data[96..128])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let px = Fq::from_slice(&data[0..32]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let py = Fq::from_slice(&data[32..64]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let qx = Fq::from_slice(&data[64..96]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let qy = Fq::from_slice(&data[96..128]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
 
         let p = if px == Fq::zero() && py == Fq::zero() {
             G1::zero()
         } else {
-            AffineG1::new(px, py).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?.into()
+            AffineG1::new(px, py)
+                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?
+                .into()
         };
         let q = if qx == Fq::zero() && qy == Fq::zero() {
             G1::zero()
         } else {
-            AffineG1::new(qx, qy).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?.into()
+            AffineG1::new(qx, qy)
+                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?
+                .into()
         };
 
         let mut output = vec![0u8; 64];
@@ -57,7 +57,7 @@ pub static BN128_MUL_PRECOMPILED: Bn128MulPrecompiled = Bn128MulPrecompiled;
 pub struct Bn128MulPrecompiled;
 impl Precompiled for Bn128MulPrecompiled {
     fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
-        use bn::{G1, AffineG1, Fq, Fr, Group};
+        use bn::{AffineG1, Fq, Fr, Group, G1};
 
         let gas = Gas::from(40000usize);
         if gas > gas_limit {
@@ -70,17 +70,16 @@ impl Precompiled for Bn128MulPrecompiled {
             data.push(0);
         }
 
-        let px = Fq::from_slice(&data[0..32])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-        let py = Fq::from_slice(&data[32..64])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-        let fr = Fr::from_slice(&data[64..96])
-            .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let px = Fq::from_slice(&data[0..32]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let py = Fq::from_slice(&data[32..64]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+        let fr = Fr::from_slice(&data[64..96]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
 
         let p = if px == Fq::zero() && py == Fq::zero() {
             G1::zero()
         } else {
-            AffineG1::new(px, py).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?.into()
+            AffineG1::new(px, py)
+                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?
+                .into()
         };
 
         let mut output = vec![0u8; 64];
@@ -98,21 +97,15 @@ pub static BN128_PAIRING_PRECOMPILED: Bn128PairingPrecompiled = Bn128PairingPrec
 pub struct Bn128PairingPrecompiled;
 impl Precompiled for Bn128PairingPrecompiled {
     fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
-        use bn::{G1, AffineG1, Fq, Group, pairing, Gt, G2, Fq2, AffineG2};
+        use bn::{pairing, AffineG1, AffineG2, Fq, Fq2, Group, Gt, G1, G2};
 
         fn read_one(s: &[u8]) -> Result<(G1, G2), RuntimeError> {
-            let ax = Fq::from_slice(&s[0..32])
-                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-            let ay = Fq::from_slice(&s[32..64])
-                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-            let bay = Fq::from_slice(&s[64..96])
-                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-            let bax = Fq::from_slice(&s[96..128])
-                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-            let bby = Fq::from_slice(&s[128..160])
-                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
-            let bbx = Fq::from_slice(&s[160..192])
-                .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+            let ax = Fq::from_slice(&s[0..32]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+            let ay = Fq::from_slice(&s[32..64]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+            let bay = Fq::from_slice(&s[64..96]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+            let bax = Fq::from_slice(&s[96..128]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+            let bby = Fq::from_slice(&s[128..160]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
+            let bbx = Fq::from_slice(&s[160..192]).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?;
 
             let ba = Fq2::new(bax, bay);
             let bb = Fq2::new(bbx, bby);
@@ -120,12 +113,16 @@ impl Precompiled for Bn128PairingPrecompiled {
             let b = if ba.is_zero() && bb.is_zero() {
                 G2::zero()
             } else {
-                AffineG2::new(ba, bb).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?.into()
+                AffineG2::new(ba, bb)
+                    .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?
+                    .into()
             };
             let a = if ax.is_zero() && ay.is_zero() {
                 G1::zero()
             } else {
-                AffineG1::new(ax, ay).map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?.into()
+                AffineG1::new(ax, ay)
+                    .map_err(|_| RuntimeError::OnChain(OnChainError::EmptyGas))?
+                    .into()
             };
 
             Ok((a, b))
@@ -143,15 +140,11 @@ impl Precompiled for Bn128PairingPrecompiled {
 
         let mut acc = Gt::one();
         for i in 0..ele_len {
-            let (a, b) = read_one(&data[i*192..i*192+192])?;
+            let (a, b) = read_one(&data[i * 192..i * 192 + 192])?;
             acc = acc * pairing(a, b);
         }
 
-        let result = if acc == Gt::one() {
-            U256::from(1)
-        } else {
-            U256::zero()
-        };
+        let result = if acc == Gt::one() { U256::from(1) } else { U256::zero() };
 
         let mut output = vec![0u8; 32];
         result.to_big_endian(&mut output);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+max_width = 120
+newline_style = "Unix"
+use_try_shorthand = true
+

--- a/src/commit/blockhash.rs
+++ b/src/commit/blockhash.rs
@@ -1,10 +1,12 @@
 //! Blockhash commitment management
 
-#[cfg(feature = "std")] use std::collections::HashMap as Map;
-#[cfg(not(feature = "std"))] use alloc::collections::BTreeMap as Map;
-use bigint::{U256, H256};
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap as Map;
+use bigint::{H256, U256};
+#[cfg(feature = "std")]
+use std::collections::HashMap as Map;
 
-use crate::errors::{RequireError, CommitError};
+use crate::errors::{CommitError, RequireError};
 
 #[derive(Debug, Clone)]
 /// A struct that manages the current blockhash state for one EVM.

--- a/src/commit/mod.rs
+++ b/src/commit/mod.rs
@@ -3,5 +3,5 @@
 mod account;
 mod blockhash;
 
-pub use self::account::{AccountCommitment, AccountChange, AccountState, Storage};
+pub use self::account::{AccountChange, AccountCommitment, AccountState, Storage};
 pub use self::blockhash::BlockhashState;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,10 +97,8 @@ pub enum RuntimeError {
 impl From<RuntimeError> for EvalError {
     fn from(val: RuntimeError) -> EvalError {
         match val {
-            RuntimeError::OnChain(err) =>
-                EvalError::OnChain(err),
-            RuntimeError::NotSupported(err) =>
-                EvalError::NotSupported(err),
+            RuntimeError::OnChain(err) => EvalError::OnChain(err),
+            RuntimeError::NotSupported(err) => EvalError::NotSupported(err),
         }
     }
 }
@@ -118,10 +116,8 @@ pub enum EvalOnChainError {
 impl From<EvalOnChainError> for EvalError {
     fn from(val: EvalOnChainError) -> EvalError {
         match val {
-            EvalOnChainError::OnChain(err) =>
-                EvalError::OnChain(err),
-            EvalOnChainError::Require(err) =>
-                EvalError::Require(err),
+            EvalOnChainError::OnChain(err) => EvalError::OnChain(err),
+            EvalOnChainError::Require(err) => EvalError::Require(err),
         }
     }
 }

--- a/src/eval/check.rs
+++ b/src/eval/check.rs
@@ -1,17 +1,22 @@
 //! Check logic for instructions
 
-use bigint::{U256, M256, Gas};
+use bigint::{Gas, M256, U256};
 
 use crate::{
-    Memory, Instruction, Patch,
-    errors::{OnChainError, NotSupportedError, EvalOnChainError},
-    eval::{State, Runtime, ControlCheck},
+    errors::{EvalOnChainError, NotSupportedError, OnChainError},
+    eval::{ControlCheck, Runtime, State},
+    Instruction, Memory, Patch,
 };
 
 use super::util::check_range;
 
 #[allow(unused_variables)]
-pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>, stipend_gas: Gas, after_gas: Gas) -> Result<(), OnChainError> {
+pub fn extra_check_opcode<M: Memory + Default, P: Patch>(
+    instruction: Instruction,
+    state: &State<M, P>,
+    stipend_gas: Gas,
+    after_gas: Gas,
+) -> Result<(), OnChainError> {
     match instruction {
         Instruction::CALL | Instruction::CALLCODE | Instruction::DELEGATECALL => {
             if P::err_on_call_with_more_gas() && after_gas < state.stack.peek(0).unwrap().into() {
@@ -19,132 +24,138 @@ pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instructio
             } else {
                 Ok(())
             }
-        },
-        _ => Ok(())
+        }
+        _ => Ok(()),
     }
 }
 
-pub fn check_support<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Result<(), NotSupportedError> {
+pub fn check_support<M: Memory + Default, P: Patch>(
+    instruction: Instruction,
+    state: &State<M, P>,
+) -> Result<(), NotSupportedError> {
     match instruction {
         Instruction::MSTORE => {
             state.memory.check_write(state.stack.peek(0).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::MSTORE8 => {
             state.memory.check_write(state.stack.peek(0).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::CALLDATACOPY => {
-            state.memory.check_write_range(
-                state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
+            state
+                .memory
+                .check_write_range(state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::CODECOPY => {
-            state.memory.check_write_range(
-                state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
+            state
+                .memory
+                .check_write_range(state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::EXTCODECOPY => {
-            state.memory.check_write_range(
-                state.stack.peek(1).unwrap().into(), state.stack.peek(3).unwrap().into())?;
+            state
+                .memory
+                .check_write_range(state.stack.peek(1).unwrap().into(), state.stack.peek(3).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::CALL => {
-            state.memory.check_write_range(
-                state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
+            state
+                .memory
+                .check_write_range(state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::CALLCODE => {
-            state.memory.check_write_range(
-                state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
+            state
+                .memory
+                .check_write_range(state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
             Ok(())
-        },
+        }
         Instruction::DELEGATECALL => {
-            state.memory.check_write_range(
-                state.stack.peek(4).unwrap().into(), state.stack.peek(5).unwrap().into())?;
+            state
+                .memory
+                .check_write_range(state.stack.peek(4).unwrap().into(), state.stack.peek(5).unwrap().into())?;
             Ok(())
-        },
+        }
         _ => Ok(()),
     }
 }
 
 #[allow(unused_variables)]
 /// Check whether `run_opcode` would be static.
-pub fn check_static<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>, runtime: &Runtime) -> Result<(), EvalOnChainError> {
+pub fn check_static<M: Memory + Default, P: Patch>(
+    instruction: Instruction,
+    state: &State<M, P>,
+    runtime: &Runtime,
+) -> Result<(), EvalOnChainError> {
     match instruction {
-        Instruction::STOP |
-        Instruction::ADD |
-        Instruction::MUL |
-        Instruction::SUB |
-        Instruction::DIV |
-        Instruction::SDIV |
-        Instruction::MOD |
-        Instruction::SMOD |
-        Instruction::ADDMOD |
-        Instruction::MULMOD |
-        Instruction::EXP |
-        Instruction::SIGNEXTEND => Ok(()),
+        Instruction::STOP
+        | Instruction::ADD
+        | Instruction::MUL
+        | Instruction::SUB
+        | Instruction::DIV
+        | Instruction::SDIV
+        | Instruction::MOD
+        | Instruction::SMOD
+        | Instruction::ADDMOD
+        | Instruction::MULMOD
+        | Instruction::EXP
+        | Instruction::SIGNEXTEND => Ok(()),
 
-        Instruction::LT |
-        Instruction::GT |
-        Instruction::SLT |
-        Instruction::SGT |
-        Instruction::EQ |
-        Instruction::ISZERO |
-        Instruction::AND |
-        Instruction::OR |
-        Instruction::XOR |
-        Instruction::NOT |
-        Instruction::BYTE => Ok(()),
+        Instruction::LT
+        | Instruction::GT
+        | Instruction::SLT
+        | Instruction::SGT
+        | Instruction::EQ
+        | Instruction::ISZERO
+        | Instruction::AND
+        | Instruction::OR
+        | Instruction::XOR
+        | Instruction::NOT
+        | Instruction::BYTE => Ok(()),
 
-        Instruction::SHL |
-        Instruction::SHR |
-        Instruction::SAR => Ok(()),
+        Instruction::SHL | Instruction::SHR | Instruction::SAR => Ok(()),
 
         Instruction::SHA3 => Ok(()),
 
-        Instruction::ADDRESS |
-        Instruction::BALANCE |
-        Instruction::ORIGIN |
-        Instruction::CALLER |
-        Instruction::CALLVALUE |
-        Instruction::CALLDATALOAD |
-        Instruction::CALLDATASIZE |
-        Instruction::CALLDATACOPY |
-        Instruction::CODESIZE |
-        Instruction::CODECOPY |
-        Instruction::GASPRICE |
-        Instruction::EXTCODESIZE |
-        Instruction::EXTCODECOPY |
-        Instruction::EXTCODEHASH |
-        Instruction::RETURNDATASIZE |
-        Instruction::RETURNDATACOPY => Ok(()),
+        Instruction::ADDRESS
+        | Instruction::BALANCE
+        | Instruction::ORIGIN
+        | Instruction::CALLER
+        | Instruction::CALLVALUE
+        | Instruction::CALLDATALOAD
+        | Instruction::CALLDATASIZE
+        | Instruction::CALLDATACOPY
+        | Instruction::CODESIZE
+        | Instruction::CODECOPY
+        | Instruction::GASPRICE
+        | Instruction::EXTCODESIZE
+        | Instruction::EXTCODECOPY
+        | Instruction::EXTCODEHASH
+        | Instruction::RETURNDATASIZE
+        | Instruction::RETURNDATACOPY => Ok(()),
 
-        Instruction::BLOCKHASH |
-        Instruction::COINBASE |
-        Instruction::TIMESTAMP |
-        Instruction::NUMBER |
-        Instruction::DIFFICULTY |
-        Instruction::GASLIMIT => Ok(()),
+        Instruction::BLOCKHASH
+        | Instruction::COINBASE
+        | Instruction::TIMESTAMP
+        | Instruction::NUMBER
+        | Instruction::DIFFICULTY
+        | Instruction::GASLIMIT => Ok(()),
 
-        Instruction::POP |
-        Instruction::MLOAD |
-        Instruction::MSTORE |
-        Instruction::MSTORE8 => Ok(()),
+        Instruction::POP | Instruction::MLOAD | Instruction::MSTORE | Instruction::MSTORE8 => Ok(()),
 
         Instruction::SLOAD => Ok(()),
         Instruction::SSTORE => Err(EvalOnChainError::OnChain(OnChainError::NotStatic)),
 
-        Instruction::JUMP |
-        Instruction::JUMPI |
-        Instruction::PC |
-        Instruction::MSIZE |
-        Instruction::GAS |
-        Instruction::JUMPDEST => Ok(()),
+        Instruction::JUMP
+        | Instruction::JUMPI
+        | Instruction::PC
+        | Instruction::MSIZE
+        | Instruction::GAS
+        | Instruction::JUMPDEST => Ok(()),
 
-        Instruction::PUSH(_) |
-        Instruction::DUP(_) |
-        Instruction::SWAP(_) => Ok(()),
+        Instruction::PUSH(_) | Instruction::DUP(_) | Instruction::SWAP(_) => Ok(()),
 
         Instruction::LOG(_) => Err(EvalOnChainError::OnChain(OnChainError::NotStatic)),
         Instruction::CREATE => Err(EvalOnChainError::OnChain(OnChainError::NotStatic)),
@@ -156,7 +167,7 @@ pub fn check_static<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             } else {
                 Ok(())
             }
-        },
+        }
         Instruction::STATICCALL => Ok(()),
         Instruction::CALLCODE => Ok(()),
         Instruction::RETURN => Ok(()),
@@ -167,9 +178,14 @@ pub fn check_static<M: Memory + Default, P: Patch>(instruction: Instruction, sta
 }
 
 #[allow(unused_variables)]
+#[rustfmt::skip]
 /// Check whether `run_opcode` would fail without mutating any of the
 /// machine state.
-pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>, runtime: &Runtime) -> Result<Option<ControlCheck>, EvalOnChainError> {
+pub fn check_opcode<M: Memory + Default, P: Patch>(
+    instruction: Instruction,
+    state: &State<M, P>,
+    runtime: &Runtime,
+) -> Result<Option<ControlCheck>, EvalOnChainError> {
     match instruction {
         Instruction::STOP => Ok(None),
         Instruction::ADD => { state.stack.check_pop_push(2, 1)?; Ok(None) },
@@ -204,14 +220,14 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             state.stack.check_pop_push(2, 1)?;
             check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
 
         Instruction::ADDRESS => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::BALANCE => {
             state.stack.check_pop_push(1, 1)?;
             state.account_state.require(state.stack.peek(0).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::ORIGIN => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CALLER => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CALLVALUE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
@@ -221,25 +237,25 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             state.stack.check_pop_push(3, 0)?;
             check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::CODESIZE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CODECOPY => {
             state.stack.check_pop_push(3, 0)?;
             check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::GASPRICE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::EXTCODESIZE => {
             state.stack.check_pop_push(1, 1)?;
             state.account_state.require_code(state.stack.peek(0).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::EXTCODECOPY => {
             state.stack.check_pop_push(4, 0)?;
             state.account_state.require_code(state.stack.peek(0).unwrap().into())?;
             check_range(state.stack.peek(1).unwrap().into(), state.stack.peek(3).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::EXTCODEHASH => {
             state.stack.check_pop_push(1, 1)?;
             state.account_state.require_code(state.stack.peek(0).unwrap().into())?;
@@ -256,7 +272,7 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             } else {
                 Ok(None)
             }
-        },
+        }
 
         Instruction::BLOCKHASH => {
             state.stack.check_pop_push(1, 1)?;
@@ -266,7 +282,7 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
                 runtime.blockhash_state.get(number)?;
             }
             Ok(None)
-        },
+        }
         Instruction::COINBASE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::TIMESTAMP => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::NUMBER => { state.stack.check_pop_push(0, 1)?; Ok(None) },
@@ -278,27 +294,31 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
         Instruction::MSTORE => {
             state.stack.check_pop_push(2, 0)?;
             Ok(None)
-        },
+        }
         Instruction::MSTORE8 => {
             state.stack.check_pop_push(2, 0)?;
             Ok(None)
-        },
+        }
         Instruction::SLOAD => {
             state.stack.check_pop_push(1, 1)?;
             state.account_state.require(state.context.address)?;
-            state.account_state.require_storage(state.context.address, state.stack.peek(0).unwrap().into())?;
+            state
+                .account_state
+                .require_storage(state.context.address, state.stack.peek(0).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::SSTORE => {
             state.stack.check_pop_push(2, 0)?;
             state.account_state.require(state.context.address)?;
-            state.account_state.require_storage(state.context.address, state.stack.peek(0).unwrap().into())?;
+            state
+                .account_state
+                .require_storage(state.context.address, state.stack.peek(0).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::JUMP => {
             state.stack.check_pop_push(1, 0)?;
             Ok(Some(ControlCheck::Jump(state.stack.peek(0).unwrap())))
-        },
+        }
         Instruction::JUMPI => {
             state.stack.check_pop_push(2, 0)?;
             if state.stack.peek(1).unwrap() != M256::zero() {
@@ -306,7 +326,7 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             } else {
                 Ok(None)
             }
-        },
+        }
         Instruction::PC => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::MSIZE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::GAS => { state.stack.check_pop_push(0, 1)?; Ok(None) },
@@ -318,16 +338,16 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
         Instruction::SWAP(v) => { state.stack.check_pop_push(v+1, v+1)?; Ok(None) },
 
         Instruction::LOG(v) => {
-            state.stack.check_pop_push(v+2, 0)?;
+            state.stack.check_pop_push(v + 2, 0)?;
             check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::CREATE | Instruction::CREATE2 => {
             state.stack.check_pop_push(3, 1)?;
             check_range(state.stack.peek(1).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             state.account_state.require(state.context.address)?;
             Ok(None)
-        },
+        }
         Instruction::CALL => {
             state.stack.check_pop_push(7, 1)?;
             check_range(state.stack.peek(3).unwrap().into(), state.stack.peek(4).unwrap().into())?;
@@ -335,7 +355,7 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::STATICCALL => {
             state.stack.check_pop_push(6, 1)?;
             check_range(state.stack.peek(2).unwrap().into(), state.stack.peek(3).unwrap().into())?;
@@ -343,7 +363,7 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::CALLCODE => {
             state.stack.check_pop_push(7, 1)?;
             check_range(state.stack.peek(3).unwrap().into(), state.stack.peek(4).unwrap().into())?;
@@ -351,17 +371,17 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::RETURN => {
             state.stack.check_pop_push(2, 0)?;
             check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::REVERT => {
             state.stack.check_pop_push(2, 0)?;
             check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::DELEGATECALL => {
             state.stack.check_pop_push(6, 1)?;
             check_range(state.stack.peek(2).unwrap().into(), state.stack.peek(3).unwrap().into())?;
@@ -369,12 +389,12 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
-        },
+        }
         Instruction::SUICIDE => {
             state.stack.check_pop_push(1, 0)?;
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(0).unwrap().into())?;
             Ok(None)
-        },
+        }
     }
 }

--- a/src/eval/run/arithmetic.rs
+++ b/src/eval/run/arithmetic.rs
@@ -2,8 +2,8 @@
 
 use bigint::{M256, U512};
 
-use crate::{Memory, Patch};
 use super::State;
+use crate::{Memory, Patch};
 
 pub fn addmod<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1: U512, op2: U512, op3: U512);
@@ -26,7 +26,6 @@ pub fn mulmod<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
         push!(state, v.into());
     }
 }
-
 
 pub fn exp<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1, op2);

--- a/src/eval/run/bitwise.rs
+++ b/src/eval/run/bitwise.rs
@@ -1,9 +1,9 @@
 //! Bitwise instructions
 
-use bigint::{M256, MI256, Sign};
+use bigint::{Sign, M256, MI256};
 
-use crate::{Memory, Patch};
 use super::State;
+use crate::{Memory, Patch};
 
 pub fn iszero<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1);
@@ -72,13 +72,9 @@ pub fn sar<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
         let MI256(sign, _) = value;
         match sign {
             // value is 0 or >=1, pushing 0
-            Sign::Plus | Sign::NoSign => {
-                M256::zero()
-            },
+            Sign::Plus | Sign::NoSign => M256::zero(),
             // value is <0, pushing -1
-            Sign::Minus => {
-                MI256(Sign::Minus, M256::one()).into()
-            }
+            Sign::Minus => MI256(Sign::Minus, M256::one()).into(),
         }
     } else {
         let shift: u64 = shift.into();
@@ -87,7 +83,7 @@ pub fn sar<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
             Sign::Plus | Sign::NoSign => {
                 let shifted = value.1 >> shift as usize;
                 shifted
-            },
+            }
             Sign::Minus => {
                 let shifted = ((value.1 - M256::one()) >> shift as usize) + M256::one();
                 MI256(Sign::Minus, shifted).into()

--- a/src/eval/run/environment.rs
+++ b/src/eval/run/environment.rs
@@ -1,10 +1,10 @@
 //! Environment instructions
 
 use bigint::{H256, M256};
-use sha3::{Keccak256, Digest};
+use sha3::{Digest, Keccak256};
 
-use crate::{Memory, Address, Patch};
 use super::State;
+use crate::{Address, Memory, Patch};
 
 pub fn calldataload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index);
@@ -49,13 +49,21 @@ mod tests {
     fn extcodehash_empty_code() {
         let code = &[];
         let hash = extcodehash_impl(code);
-        assert_eq!(hash, H256::from("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        assert_eq!(
+            hash,
+            H256::from("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+        );
     }
 
     #[test]
     fn extcodehash_hash() {
-        let code = &[0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x63, 0x6f, 0x64, 0x65, 0x68, 0x61, 0x73, 0x68];
+        let code = &[
+            0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x63, 0x6f, 0x64, 0x65, 0x68, 0x61, 0x73, 0x68,
+        ];
         let hash = extcodehash_impl(code);
-        assert_eq!(hash, H256::from("0x854a9ae2c913e6cef584ecaf9cbb52a38b59fb923a09beccee9d17c17d15cf7a"));
+        assert_eq!(
+            hash,
+            H256::from("0x854a9ae2c913e6cef584ecaf9cbb52a38b59fb923a09beccee9d17c17d15cf7a")
+        );
     }
 }

--- a/src/eval/run/flow.rs
+++ b/src/eval/run/flow.rs
@@ -1,8 +1,8 @@
 //! Flow control instructions.
 
-use bigint::{U256, M256};
-use crate::{Memory, Patch};
 use super::State;
+use crate::{Memory, Patch};
+use bigint::{M256, U256};
 
 pub fn sload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256);
@@ -12,7 +12,10 @@ pub fn sload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
 
 pub fn sstore<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256, value: M256);
-    state.account_state.storage_write(state.context.address, index, value).unwrap();
+    state
+        .account_state
+        .storage_write(state.context.address, index, value)
+        .unwrap();
 }
 
 pub fn mload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {

--- a/src/eval/run/mod.rs
+++ b/src/eval/run/mod.rs
@@ -22,173 +22,378 @@ macro_rules! push {
 }
 
 macro_rules! op2 {
-    ( $machine:expr, $op:ident ) => ({
+    ( $machine:expr, $op:ident ) => {{
         pop!($machine, op1, op2);
         push!($machine, op1.$op(op2).into());
-    });
-    ( $machine:expr, $op:ident, $t:ty ) => ({
-        pop!($machine, op1:$t, op2:$t);
+    }};
+    ( $machine:expr, $op:ident, $t:ty ) => {{
+        pop!($machine, op1: $t, op2: $t);
         push!($machine, op1.$op(op2).into());
-    });
+    }};
 }
 
 macro_rules! op2_ref {
-    ( $machine:expr, $op:ident ) => ({
+    ( $machine:expr, $op:ident ) => {{
         pop!($machine, op1, op2);
         push!($machine, op1.$op(&op2).into());
-    });
-    ( $machine:expr, $op:ident, $t:ty ) => ({
-        pop!($machine, op1:$t, op2:$t);
+    }};
+    ( $machine:expr, $op:ident, $t:ty ) => {{
+        pop!($machine, op1: $t, op2: $t);
         push!($machine, op1.$op(&op2).into());
-    });
+    }};
 }
 
 mod arithmetic;
 mod bitwise;
-mod flow;
 mod environment;
+mod flow;
 mod system;
 
-#[cfg(not(feature = "std"))] use alloc::rc::Rc;
-#[cfg(feature = "std")] use std::rc::Rc;
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
+use std::rc::Rc;
 
-use bigint::{M256, MI256, U256, Address, Gas};
-#[cfg(feature = "std")] use std::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor};
-#[cfg(not(feature = "std"))] use core::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor};
-use crate::{Memory, Instruction, Patch};
-use super::{State, Runtime, Control};
 use super::util::{copy_from_memory, copy_into_memory};
+use super::{Control, Runtime, State};
+use crate::{Instruction, Memory, Patch};
+use bigint::{Address, Gas, M256, MI256, U256};
+#[cfg(not(feature = "std"))]
+use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Sub};
+#[cfg(feature = "std")]
+use std::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Rem, Sub};
 
 #[allow(unused_variables)]
 /// Run an instruction.
-pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state: &mut State<M, P>, runtime: &Runtime, stipend_gas: Gas, after_gas: Gas) -> Option<Control> {
+pub fn run_opcode<M: Memory + Default, P: Patch>(
+    pc: (Instruction, usize),
+    state: &mut State<M, P>,
+    runtime: &Runtime,
+    stipend_gas: Gas,
+    after_gas: Gas,
+) -> Option<Control> {
     match pc.0 {
-        Instruction::STOP => { Some(Control::Stop) },
-        Instruction::ADD => { op2!(state, add); None },
-        Instruction::MUL => { op2!(state, mul); None },
-        Instruction::SUB => { op2!(state, sub); None },
-        Instruction::DIV => { op2!(state, div); None },
-        Instruction::SDIV => { op2!(state, div, MI256); None },
-        Instruction::MOD => { op2!(state, rem); None },
-        Instruction::SMOD => { op2!(state, rem, MI256); None },
-        Instruction::ADDMOD => { arithmetic::addmod(state); None },
-        Instruction::MULMOD => { arithmetic::mulmod(state); None },
-        Instruction::EXP => { arithmetic::exp(state); None },
-        Instruction::SIGNEXTEND => { arithmetic::signextend(state); None },
+        Instruction::STOP => Some(Control::Stop),
+        Instruction::ADD => {
+            op2!(state, add);
+            None
+        }
+        Instruction::MUL => {
+            op2!(state, mul);
+            None
+        }
+        Instruction::SUB => {
+            op2!(state, sub);
+            None
+        }
+        Instruction::DIV => {
+            op2!(state, div);
+            None
+        }
+        Instruction::SDIV => {
+            op2!(state, div, MI256);
+            None
+        }
+        Instruction::MOD => {
+            op2!(state, rem);
+            None
+        }
+        Instruction::SMOD => {
+            op2!(state, rem, MI256);
+            None
+        }
+        Instruction::ADDMOD => {
+            arithmetic::addmod(state);
+            None
+        }
+        Instruction::MULMOD => {
+            arithmetic::mulmod(state);
+            None
+        }
+        Instruction::EXP => {
+            arithmetic::exp(state);
+            None
+        }
+        Instruction::SIGNEXTEND => {
+            arithmetic::signextend(state);
+            None
+        }
 
-        Instruction::LT => { op2_ref!(state, lt); None },
-        Instruction::GT => { op2_ref!(state, gt); None },
-        Instruction::SLT => { op2_ref!(state, lt, MI256); None },
-        Instruction::SGT => { op2_ref!(state, gt, MI256); None },
-        Instruction::EQ => { op2_ref!(state, eq); None },
-        Instruction::ISZERO => { bitwise::iszero(state); None },
-        Instruction::AND => { op2!(state, bitand); None },
-        Instruction::OR => { op2!(state, bitor); None },
-        Instruction::XOR => { op2!(state, bitxor); None },
-        Instruction::NOT => { bitwise::not(state); None },
-        Instruction::BYTE => { bitwise::byte(state); None },
+        Instruction::LT => {
+            op2_ref!(state, lt);
+            None
+        }
+        Instruction::GT => {
+            op2_ref!(state, gt);
+            None
+        }
+        Instruction::SLT => {
+            op2_ref!(state, lt, MI256);
+            None
+        }
+        Instruction::SGT => {
+            op2_ref!(state, gt, MI256);
+            None
+        }
+        Instruction::EQ => {
+            op2_ref!(state, eq);
+            None
+        }
+        Instruction::ISZERO => {
+            bitwise::iszero(state);
+            None
+        }
+        Instruction::AND => {
+            op2!(state, bitand);
+            None
+        }
+        Instruction::OR => {
+            op2!(state, bitor);
+            None
+        }
+        Instruction::XOR => {
+            op2!(state, bitxor);
+            None
+        }
+        Instruction::NOT => {
+            bitwise::not(state);
+            None
+        }
+        Instruction::BYTE => {
+            bitwise::byte(state);
+            None
+        }
 
-        Instruction::SHL => { bitwise::shl(state); None },
-        Instruction::SHR => { bitwise::shr(state); None },
-        Instruction::SAR => { bitwise::sar(state); None },
+        Instruction::SHL => {
+            bitwise::shl(state);
+            None
+        }
+        Instruction::SHR => {
+            bitwise::shr(state);
+            None
+        }
+        Instruction::SAR => {
+            bitwise::sar(state);
+            None
+        }
 
-        Instruction::SHA3 => { system::sha3(state); None },
+        Instruction::SHA3 => {
+            system::sha3(state);
+            None
+        }
 
-        Instruction::ADDRESS => { push!(state, state.context.address.into()); None },
-        Instruction::BALANCE => { pop!(state, address: Address);
-                                  push!(state, state.account_state.balance(address).unwrap().into());
-                                  None },
-        Instruction::ORIGIN => { push!(state, state.context.origin.into()); None },
-        Instruction::CALLER => { push!(state, state.context.caller.into()); None },
-        Instruction::CALLVALUE => { push!(state, state.context.apprent_value.into()); None },
-        Instruction::CALLDATALOAD => { environment::calldataload(state); None },
-        Instruction::CALLDATASIZE => { push!(state, state.context.data.len().into()); None },
-        Instruction::CALLDATACOPY => { pop!(state, memory_index: U256, data_index: U256, len: U256);
-                                       copy_into_memory(&mut state.memory,
-                                                        state.context.data.as_slice(),
-                                                        memory_index, data_index, len);
-                                       None },
-        Instruction::CODESIZE => { push!(state, state.context.code.len().into()); None },
-        Instruction::CODECOPY => { pop!(state, memory_index: U256, code_index: U256, len: U256);
-                                   copy_into_memory(&mut state.memory,
-                                                    state.context.code.as_slice(),
-                                                    memory_index, code_index, len);
-                                   None },
-        Instruction::GASPRICE => { push!(state, state.context.gas_price.into()); None },
-        Instruction::EXTCODESIZE => { pop!(state, address: Address);
-                                      push!(state,
-                                            state.account_state.code(address).unwrap().len().into());
-                                      None },
-        Instruction::EXTCODECOPY => { pop!(state, address: Address);
-                                      pop!(state, memory_index: U256, code_index: U256, len: U256);
-                                      copy_into_memory(&mut state.memory,
-                                                       &state.account_state.code(address).unwrap(),
-                                                       memory_index, code_index, len);
-                                      None },
-        Instruction::EXTCODEHASH => { environment::extcodehash(state); None },
-        Instruction::RETURNDATASIZE => { push!(state, state.ret.len().into()); None },
-        Instruction::RETURNDATACOPY => { pop!(state, memory_index: U256, data_index: U256, len: U256);
-                                         copy_into_memory(&mut state.memory,
-                                                          state.ret.as_slice(),
-                                                          memory_index, data_index, len);
-                                         None },
+        Instruction::ADDRESS => {
+            push!(state, state.context.address.into());
+            None
+        }
+        Instruction::BALANCE => {
+            pop!(state, address: Address);
+            push!(state, state.account_state.balance(address).unwrap().into());
+            None
+        }
+        Instruction::ORIGIN => {
+            push!(state, state.context.origin.into());
+            None
+        }
+        Instruction::CALLER => {
+            push!(state, state.context.caller.into());
+            None
+        }
+        Instruction::CALLVALUE => {
+            push!(state, state.context.apprent_value.into());
+            None
+        }
+        Instruction::CALLDATALOAD => {
+            environment::calldataload(state);
+            None
+        }
+        Instruction::CALLDATASIZE => {
+            push!(state, state.context.data.len().into());
+            None
+        }
+        Instruction::CALLDATACOPY => {
+            pop!(state, memory_index: U256, data_index: U256, len: U256);
+            copy_into_memory(
+                &mut state.memory,
+                state.context.data.as_slice(),
+                memory_index,
+                data_index,
+                len,
+            );
+            None
+        }
+        Instruction::CODESIZE => {
+            push!(state, state.context.code.len().into());
+            None
+        }
+        Instruction::CODECOPY => {
+            pop!(state, memory_index: U256, code_index: U256, len: U256);
+            copy_into_memory(
+                &mut state.memory,
+                state.context.code.as_slice(),
+                memory_index,
+                code_index,
+                len,
+            );
+            None
+        }
+        Instruction::GASPRICE => {
+            push!(state, state.context.gas_price.into());
+            None
+        }
+        Instruction::EXTCODESIZE => {
+            pop!(state, address: Address);
+            push!(state, state.account_state.code(address).unwrap().len().into());
+            None
+        }
+        Instruction::EXTCODECOPY => {
+            pop!(state, address: Address);
+            pop!(state, memory_index: U256, code_index: U256, len: U256);
+            copy_into_memory(
+                &mut state.memory,
+                &state.account_state.code(address).unwrap(),
+                memory_index,
+                code_index,
+                len,
+            );
+            None
+        }
+        Instruction::EXTCODEHASH => {
+            environment::extcodehash(state);
+            None
+        }
+        Instruction::RETURNDATASIZE => {
+            push!(state, state.ret.len().into());
+            None
+        }
+        Instruction::RETURNDATACOPY => {
+            pop!(state, memory_index: U256, data_index: U256, len: U256);
+            copy_into_memory(&mut state.memory, state.ret.as_slice(), memory_index, data_index, len);
+            None
+        }
 
-        Instruction::BLOCKHASH => { pop!(state, number: U256);
-                                    let current_number = runtime.block.number;
-                                    if !(number >= current_number || current_number - number > U256::from(256u64)) {
-                                        push!(state, M256::from(runtime.blockhash_state.get(number).unwrap()));
-                                    } else {
-                                        push!(state, M256::zero());
-                                    }
-                                    None },
-        Instruction::COINBASE => { push!(state, M256::from(runtime.block.beneficiary)); None },
-        Instruction::TIMESTAMP => { push!(state, M256::from(runtime.block.timestamp)); None },
-        Instruction::NUMBER => { push!(state, M256::from(runtime.block.number)); None },
-        Instruction::DIFFICULTY => { push!(state, M256::from(runtime.block.difficulty)); None },
-        Instruction::GASLIMIT => { push!(state, runtime.block.gas_limit.into()); None },
+        Instruction::BLOCKHASH => {
+            pop!(state, number: U256);
+            let current_number = runtime.block.number;
+            if !(number >= current_number || current_number - number > U256::from(256u64)) {
+                push!(state, M256::from(runtime.blockhash_state.get(number).unwrap()));
+            } else {
+                push!(state, M256::zero());
+            }
+            None
+        }
+        Instruction::COINBASE => {
+            push!(state, M256::from(runtime.block.beneficiary));
+            None
+        }
+        Instruction::TIMESTAMP => {
+            push!(state, M256::from(runtime.block.timestamp));
+            None
+        }
+        Instruction::NUMBER => {
+            push!(state, M256::from(runtime.block.number));
+            None
+        }
+        Instruction::DIFFICULTY => {
+            push!(state, M256::from(runtime.block.difficulty));
+            None
+        }
+        Instruction::GASLIMIT => {
+            push!(state, runtime.block.gas_limit.into());
+            None
+        }
 
-        Instruction::POP => { state.stack.pop().unwrap(); None },
-        Instruction::MLOAD => { flow::mload(state); None },
-        Instruction::MSTORE => { flow::mstore(state); None },
-        Instruction::MSTORE8 => { flow::mstore8(state); None },
-        Instruction::SLOAD => { flow::sload(state); None },
-        Instruction::SSTORE => { flow::sstore(state); None },
-        Instruction::JUMP => { pop!(state, dest); Some(Control::Jump(dest)) }
-        Instruction::JUMPI => { pop!(state, dest, value);
-                                if value != M256::zero() {
-                                    Some(Control::Jump(dest))
-                                } else {
-                                    None
-                                } },
-        Instruction::PC => { push!(state, pc.1.into()); None },
-        Instruction::MSIZE => { push!(state, (state.memory_cost * Gas::from(32u64)).into()); None },
-        Instruction::GAS => { push!(state, after_gas.into()); None },
+        Instruction::POP => {
+            state.stack.pop().unwrap();
+            None
+        }
+        Instruction::MLOAD => {
+            flow::mload(state);
+            None
+        }
+        Instruction::MSTORE => {
+            flow::mstore(state);
+            None
+        }
+        Instruction::MSTORE8 => {
+            flow::mstore8(state);
+            None
+        }
+        Instruction::SLOAD => {
+            flow::sload(state);
+            None
+        }
+        Instruction::SSTORE => {
+            flow::sstore(state);
+            None
+        }
+        Instruction::JUMP => {
+            pop!(state, dest);
+            Some(Control::Jump(dest))
+        }
+        Instruction::JUMPI => {
+            pop!(state, dest, value);
+            if value != M256::zero() {
+                Some(Control::Jump(dest))
+            } else {
+                None
+            }
+        }
+        Instruction::PC => {
+            push!(state, pc.1.into());
+            None
+        }
+        Instruction::MSIZE => {
+            push!(state, (state.memory_cost * Gas::from(32u64)).into());
+            None
+        }
+        Instruction::GAS => {
+            push!(state, after_gas.into());
+            None
+        }
         Instruction::JUMPDEST => None,
 
-        Instruction::PUSH(v) => { push!(state, v); None }
+        Instruction::PUSH(v) => {
+            push!(state, v);
+            None
+        }
 
-        Instruction::DUP(v) => { let val = state.stack.peek(v-1).unwrap();
-                                 push!(state, val);
-                                 None },
-        Instruction::SWAP(v) => { let val1 = state.stack.peek(0).unwrap();
-                                  let val2 = state.stack.peek(v).unwrap();
-                                  state.stack.set(0, val2).unwrap();
-                                  state.stack.set(v, val1).unwrap();
-                                  None },
-        Instruction::LOG(v) => { system::log(state, v); None },
+        Instruction::DUP(v) => {
+            let val = state.stack.peek(v - 1).unwrap();
+            push!(state, val);
+            None
+        }
+        Instruction::SWAP(v) => {
+            let val1 = state.stack.peek(0).unwrap();
+            let val2 = state.stack.peek(v).unwrap();
+            state.stack.set(0, val2).unwrap();
+            state.stack.set(v, val1).unwrap();
+            None
+        }
+        Instruction::LOG(v) => {
+            system::log(state, v);
+            None
+        }
 
-        Instruction::CREATE => { system::create::<M, P>(state, after_gas, false) },
-        Instruction::CREATE2 => { system::create::<M, P>(state, after_gas, true) },
-        Instruction::CALL => { system::call::<M, P>(state, stipend_gas, after_gas, false) },
-        Instruction::CALLCODE => { system::call::<M, P>(state, stipend_gas, after_gas, true) },
-        Instruction::DELEGATECALL => { system::delegate_call::<M, P>(state, after_gas) },
-        Instruction::STATICCALL => { system::static_call::<M, P>(state, stipend_gas, after_gas) },
-        Instruction::RETURN => { pop!(state, start: U256, len: U256);
-                                 state.out = Rc::new(copy_from_memory(&state.memory, start, len));
-                                 Some(Control::Stop) },
-        Instruction::REVERT => { pop!(state, start: U256, len: U256);
-                                 state.out = Rc::new(copy_from_memory(&state.memory, start, len));
-                                 Some(Control::Revert) },
-        Instruction::SUICIDE => { system::suicide(state); Some(Control::Stop) },
+        Instruction::CREATE => system::create::<M, P>(state, after_gas, false),
+        Instruction::CREATE2 => system::create::<M, P>(state, after_gas, true),
+        Instruction::CALL => system::call::<M, P>(state, stipend_gas, after_gas, false),
+        Instruction::CALLCODE => system::call::<M, P>(state, stipend_gas, after_gas, true),
+        Instruction::DELEGATECALL => system::delegate_call::<M, P>(state, after_gas),
+        Instruction::STATICCALL => system::static_call::<M, P>(state, stipend_gas, after_gas),
+        Instruction::RETURN => {
+            pop!(state, start: U256, len: U256);
+            state.out = Rc::new(copy_from_memory(&state.memory, start, len));
+            Some(Control::Stop)
+        }
+        Instruction::REVERT => {
+            pop!(state, start: U256, len: U256);
+            state.out = Rc::new(copy_from_memory(&state.memory, start, len));
+            Some(Control::Revert)
+        }
+        Instruction::SUICIDE => {
+            system::suicide(state);
+            Some(Control::Stop)
+        }
     }
 }

--- a/src/eval/run/system.rs
+++ b/src/eval/run/system.rs
@@ -3,18 +3,22 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-#[cfg(not(feature = "std"))] use alloc::rc::Rc;
-#[cfg(feature = "std")] use std::rc::Rc;
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
+use std::rc::Rc;
 
-use bigint::{U256, M256, H256, Address, Gas};
+use bigint::{Address, Gas, H256, M256, U256};
 use block_core::TransactionAction;
 
-use crate::{Memory, Log, ValidTransaction, Patch};
-use crate::eval::util::{l64, copy_from_memory};
 use super::{Control, State};
+use crate::eval::util::{copy_from_memory, l64};
+use crate::{Log, Memory, Patch, ValidTransaction};
 
-#[cfg(feature = "std")] use std::cmp::min;
-#[cfg(not(feature = "std"))] use core::cmp::min;
+#[cfg(not(feature = "std"))]
+use core::cmp::min;
+#[cfg(feature = "std")]
+use std::cmp::min;
 
 use sha3::{Digest, Keccak256};
 
@@ -58,7 +62,7 @@ macro_rules! try_callstack_limit {
             push!($state, M256::zero());
             return None;
         }
-    }
+    };
 }
 
 macro_rules! try_balance {
@@ -67,11 +71,19 @@ macro_rules! try_balance {
             push!($state, M256::zero());
             return None;
         }
-    }
+    };
 }
 
-pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas: Gas, is_create2: bool) -> Option<Control> {
-    let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
+pub fn create<M: Memory + Default, P: Patch>(
+    state: &mut State<M, P>,
+    after_gas: Gas,
+    is_create2: bool,
+) -> Option<Control> {
+    let l64_after_gas = if P::call_create_l64_after_gas() {
+        l64(after_gas)
+    } else {
+        after_gas
+    };
 
     pop!(state, value: U256);
     pop!(state, init_start: U256, init_len: U256);
@@ -105,17 +117,31 @@ pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas:
         }
     };
 
-    let context = transaction.into_context::<P>(
-        Gas::zero(), Some(state.context.origin), &mut state.account_state, true,
-        state.context.is_static,
-    ).unwrap();
+    let context = transaction
+        .into_context::<P>(
+            Gas::zero(),
+            Some(state.context.origin),
+            &mut state.account_state,
+            true,
+            state.context.is_static,
+        )
+        .unwrap();
 
     push!(state, context.address.into());
     Some(Control::InvokeCreate(context))
 }
 
-pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas: Gas, after_gas: Gas, as_self: bool) -> Option<Control> {
-    let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
+pub fn call<M: Memory + Default, P: Patch>(
+    state: &mut State<M, P>,
+    stipend_gas: Gas,
+    after_gas: Gas,
+    as_self: bool,
+) -> Option<Control> {
+    let l64_after_gas = if P::call_create_l64_after_gas() {
+        l64(after_gas)
+    } else {
+        after_gas
+    };
 
     pop!(state, gas: Gas, to: Address, value: U256);
     pop!(state, in_start: U256, in_len: U256, out_start: U256, out_len: U256);
@@ -135,10 +161,15 @@ pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas:
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
 
-    let mut context = transaction.into_context::<P>(
-        Gas::zero(), Some(state.context.origin), &mut state.account_state, true,
-        state.context.is_static,
-    ).unwrap();
+    let mut context = transaction
+        .into_context::<P>(
+            Gas::zero(),
+            Some(state.context.origin),
+            &mut state.account_state,
+            true,
+            state.context.is_static,
+        )
+        .unwrap();
     if as_self {
         context.address = state.context.address;
     }
@@ -147,8 +178,16 @@ pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas:
     Some(Control::InvokeCall(context, (out_start, out_len)))
 }
 
-pub fn static_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas: Gas, after_gas: Gas) -> Option<Control> {
-    let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
+pub fn static_call<M: Memory + Default, P: Patch>(
+    state: &mut State<M, P>,
+    stipend_gas: Gas,
+    after_gas: Gas,
+) -> Option<Control> {
+    let l64_after_gas = if P::call_create_l64_after_gas() {
+        l64(after_gas)
+    } else {
+        after_gas
+    };
 
     pop!(state, gas: Gas, to: Address);
     pop!(state, in_start: U256, in_len: U256, out_start: U256, out_len: U256);
@@ -167,17 +206,26 @@ pub fn static_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipe
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
 
-    let context = transaction.into_context::<P>(
-        Gas::zero(), Some(state.context.origin), &mut state.account_state, true,
-        true,
-    ).unwrap();
+    let context = transaction
+        .into_context::<P>(
+            Gas::zero(),
+            Some(state.context.origin),
+            &mut state.account_state,
+            true,
+            true,
+        )
+        .unwrap();
 
     push!(state, M256::from(1u64));
     Some(Control::InvokeCall(context, (out_start, out_len)))
 }
 
 pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas: Gas) -> Option<Control> {
-    let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
+    let l64_after_gas = if P::call_create_l64_after_gas() {
+        l64(after_gas)
+    } else {
+        after_gas
+    };
 
     pop!(state, gas: Gas, to: Address);
     pop!(state, in_start: U256, in_len: U256, out_start: U256, out_len: U256);
@@ -196,10 +244,15 @@ pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, aft
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
 
-    let mut context = transaction.into_context::<P>(
-        Gas::zero(), Some(state.context.origin), &mut state.account_state, true,
-        state.context.is_static,
-    ).unwrap();
+    let mut context = transaction
+        .into_context::<P>(
+            Gas::zero(),
+            Some(state.context.origin),
+            &mut state.account_state,
+            true,
+            state.context.is_static,
+        )
+        .unwrap();
     context.value = U256::zero();
     context.address = state.context.address;
 

--- a/src/eval/util.rs
+++ b/src/eval/util.rs
@@ -3,11 +3,13 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use bigint::{U256, M256, Gas};
-use crate::{Memory, errors::OnChainError};
+use crate::{errors::OnChainError, Memory};
+use bigint::{Gas, M256, U256};
 
-#[cfg(feature = "std")] use std::cmp::min;
-#[cfg(not(feature = "std"))] use core::cmp::min;
+#[cfg(not(feature = "std"))]
+use core::cmp::min;
+#[cfg(feature = "std")]
+use std::cmp::min;
 
 pub fn l64(gas: Gas) -> Gas {
     gas - gas / Gas::from(64u64)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,11 +99,16 @@
 //! EVM implementations, will not handle transaction-level gas
 //! reductions.
 
-#![deny(unused_import_braces, unused_imports,
-        unused_comparisons, unused_must_use,
-        unused_variables, non_shorthand_field_patterns,
-        unreachable_code, missing_docs)]
-
+#![deny(
+    unused_import_braces,
+    unused_imports,
+    unused_comparisons,
+    unused_must_use,
+    unused_variables,
+    non_shorthand_field_patterns,
+    unreachable_code,
+    missing_docs
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
@@ -122,38 +127,43 @@ extern crate secp256k1;
 #[cfg(feature = "std")]
 extern crate block;
 
-mod util;
-mod memory;
-mod stack;
-mod pc;
-mod params;
-mod eval;
 mod commit;
-mod patch;
-mod transaction;
 pub mod errors;
+mod eval;
+mod memory;
+mod params;
+mod patch;
+mod pc;
+mod stack;
+mod transaction;
+mod util;
 
+pub use crate::commit::{AccountChange, AccountCommitment, AccountState, BlockhashState, Storage};
+pub use crate::errors::{CommitError, NotSupportedError, OnChainError, PreExecutionError, RequireError};
+pub use crate::eval::{Machine, MachineStatus, Runtime, State};
 pub use crate::memory::{Memory, SeqMemory};
-pub use crate::stack::Stack;
-pub use crate::pc::{PC, PCMut, Instruction, Valids};
 pub use crate::params::*;
 pub use crate::patch::*;
-pub use crate::eval::{State, Machine, Runtime, MachineStatus};
-pub use crate::commit::{AccountCommitment, AccountChange, AccountState, BlockhashState, Storage};
-pub use crate::transaction::{ValidTransaction, TransactionVM, UntrustedTransaction};
-pub use crate::errors::{OnChainError, NotSupportedError, RequireError, CommitError, PreExecutionError};
+pub use crate::pc::{Instruction, PCMut, Valids, PC};
+pub use crate::stack::Stack;
+pub use crate::transaction::{TransactionVM, UntrustedTransaction, ValidTransaction};
 pub use crate::util::opcode::Opcode;
 pub use block_core::TransactionAction;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-#[cfg(feature = "std")] use std::collections::{HashSet as Set, hash_map as map};
-#[cfg(not(feature = "std"))] use alloc::{collections::BTreeSet as Set, collections::btree_map as map};
-#[cfg(not(feature = "std"))] use alloc::boxed::Box;
-#[cfg(feature = "std")] use std::cmp::min;
-#[cfg(not(feature = "std"))] use core::cmp::min;
-use bigint::{U256, H256, Gas, Address};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::{collections::btree_map as map, collections::BTreeSet as Set};
+use bigint::{Address, Gas, H256, U256};
+#[cfg(not(feature = "std"))]
+use core::cmp::min;
+#[cfg(feature = "std")]
+use std::cmp::min;
+#[cfg(feature = "std")]
+use std::collections::{hash_map as map, HashSet as Set};
 
 use log::debug;
 
@@ -202,8 +212,9 @@ pub trait VM {
         loop {
             match self.status() {
                 VMStatus::Running => self.step()?,
-                VMStatus::ExitedOk | VMStatus::ExitedErr(_) |
-                VMStatus::ExitedNotSupported(_) => return Ok(()),
+                VMStatus::ExitedOk | VMStatus::ExitedErr(_) | VMStatus::ExitedNotSupported(_) => {
+                    return Ok(());
+                }
             }
         }
     }
@@ -256,8 +267,12 @@ impl<M: Memory + Default, P: Patch> ContextVM<M, P> {
     }
 
     /// Create a new VM with the given account state and blockhash state.
-    pub fn with_states(context: Context, block: HeaderParams,
-                       account_state: AccountState<P::Account>, blockhash_state: BlockhashState) -> Self {
+    pub fn with_states(
+        context: Context,
+        block: HeaderParams,
+        account_state: AccountState<P::Account>,
+        blockhash_state: BlockhashState,
+    ) -> Self {
         let mut machines = Vec::new();
         machines.push(Machine::with_states(context, 1, account_state.clone()));
         ContextVM {
@@ -269,9 +284,12 @@ impl<M: Memory + Default, P: Patch> ContextVM<M, P> {
 
     /// Create a new VM with customized initialization code.
     pub fn with_init<F: FnOnce(&mut ContextVM<M, P>)>(
-        context: Context, block: HeaderParams,
-        account_state: AccountState<P::Account>, blockhash_state: BlockhashState,
-        f: F) -> Self {
+        context: Context,
+        block: HeaderParams,
+        account_state: AccountState<P::Account>,
+        blockhash_state: BlockhashState,
+        f: F,
+    ) -> Self {
         let mut vm = Self::with_states(context, block, account_state, blockhash_state);
         f(&mut vm);
         vm.fresh_account_state = vm.machines[0].state().account_state.clone();
@@ -281,9 +299,12 @@ impl<M: Memory + Default, P: Patch> ContextVM<M, P> {
     /// Create a new VM with the result of the previous VM. This is
     /// usually used by transaction for chainning them.
     pub fn with_previous(context: Context, block: HeaderParams, vm: &ContextVM<M, P>) -> Self {
-        Self::with_states(context, block,
-                          vm.machines[0].state().account_state.clone(),
-                          vm.runtime.blockhash_state.clone())
+        Self::with_states(
+            context,
+            block,
+            vm.machines[0].state().account_state.clone(),
+            vm.runtime.blockhash_state.clone(),
+        )
     }
 
     /// Returns the current state of the VM.
@@ -326,7 +347,9 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
         }
 
         match self.machines[0].status() {
-            MachineStatus::Running | MachineStatus::InvokeCreate(_) | MachineStatus::InvokeCall(_, _) => VMStatus::Running,
+            MachineStatus::Running | MachineStatus::InvokeCreate(_) | MachineStatus::InvokeCall(_, _) => {
+                VMStatus::Running
+            }
             MachineStatus::ExitedOk => VMStatus::ExitedOk,
             MachineStatus::ExitedErr(err) => VMStatus::ExitedErr(err),
             MachineStatus::ExitedNotSupported(err) => VMStatus::ExitedNotSupported(err),
@@ -335,18 +358,14 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
 
     fn peek(&self) -> Option<Instruction> {
         match self.machines.last().unwrap().status().clone() {
-            MachineStatus::Running => {
-                self.machines.last().unwrap().peek()
-            },
+            MachineStatus::Running => self.machines.last().unwrap().peek(),
             _ => None,
         }
     }
 
     fn peek_opcode(&self) -> Option<Opcode> {
         match self.machines.last().unwrap().status().clone() {
-            MachineStatus::Running => {
-                self.machines.last().unwrap().peek_opcode()
-            },
+            MachineStatus::Running => self.machines.last().unwrap().peek_opcode(),
             _ => None,
         }
     }
@@ -357,13 +376,16 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
                 self.machines.last_mut().unwrap().step(&self.runtime)?;
                 if self.machines.len() == 1 {
                     match self.machines.last().unwrap().status().clone() {
-                        MachineStatus::ExitedOk | MachineStatus::ExitedErr(_) =>
-                            self.machines.last_mut().unwrap().finalize_context(&self.fresh_account_state),
+                        MachineStatus::ExitedOk | MachineStatus::ExitedErr(_) => self
+                            .machines
+                            .last_mut()
+                            .unwrap()
+                            .finalize_context(&self.fresh_account_state),
                         _ => (),
                     }
                 }
                 Ok(())
-            },
+            }
             MachineStatus::ExitedOk | MachineStatus::ExitedErr(_) => {
                 if self.machines.is_empty() {
                     panic!()
@@ -374,10 +396,8 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
                     self.machines.last_mut().unwrap().apply_sub(finished);
                     Ok(())
                 }
-            },
-            MachineStatus::ExitedNotSupported(_) => {
-                Ok(())
-            },
+            }
+            MachineStatus::ExitedNotSupported(_) => Ok(()),
             MachineStatus::InvokeCall(context, _) => {
                 for hook in &self.runtime.context_history_hooks {
                     hook(&context)
@@ -387,9 +407,9 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
                 sub.invoke_call()?;
                 self.machines.push(sub);
                 Ok(())
-            },
+            }
             MachineStatus::InvokeCreate(context) => {
-               for hook in &self.runtime.context_history_hooks {
+                for hook in &self.runtime.context_history_hooks {
                     hook(&context)
                 }
 
@@ -397,7 +417,7 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
                 sub.invoke_create()?;
                 self.machines.push(sub);
                 Ok(())
-            },
+            }
         }
     }
 
@@ -405,12 +425,13 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
         loop {
             debug!("machines status:");
             for (n, machine) in self.machines.iter().enumerate() {
-               debug!("Machine {}: {:x?}", n, machine.status());
+                debug!("Machine {}: {:x?}", n, machine.status());
             }
             match self.status() {
                 VMStatus::Running => self.step()?,
-                VMStatus::ExitedOk | VMStatus::ExitedErr(_) |
-                VMStatus::ExitedNotSupported(_) => return Ok(()),
+                VMStatus::ExitedOk | VMStatus::ExitedErr(_) | VMStatus::ExitedNotSupported(_) => {
+                    return Ok(());
+                }
             }
         }
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -3,13 +3,15 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use bigint::{U256, M256};
+use bigint::{M256, U256};
 
 use super::errors::NotSupportedError;
 use super::Patch;
 
-#[cfg(feature = "std")] use std::marker::PhantomData;
-#[cfg(not(feature = "std"))] use core::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+#[cfg(feature = "std")]
+use std::marker::PhantomData;
 
 /// Represent a memory in EVM. Read should always succeed. Write can
 /// fall.
@@ -58,7 +60,9 @@ impl<P: Patch> SeqMemory<P> {
 
     /// Return true if current effective memory range is zero
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<P: Patch> Memory for SeqMemory<P> {

--- a/src/params.rs
+++ b/src/params.rs
@@ -3,10 +3,12 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-#[cfg(not(feature = "std"))] use alloc::rc::Rc;
-#[cfg(feature = "std")] use std::rc::Rc;
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
+use std::rc::Rc;
 
-use bigint::{U256, Address, Gas};
+use bigint::{Address, Gas, U256};
 #[cfg(feature = "std")]
 use block::Header;
 
@@ -22,7 +24,7 @@ pub struct HeaderParams {
     /// Difficulty of the block.
     pub difficulty: U256,
     /// Total block gas limit.
-    pub gas_limit: Gas
+    pub gas_limit: Gas,
 }
 
 #[cfg(feature = "std")]

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -5,7 +5,7 @@ mod precompiled;
 
 pub use self::precompiled::*;
 
-use bigint::{Address, Gas, U256, H160};
+use bigint::{Address, Gas, H160, U256};
 
 /// Account patch for account related variables.
 pub trait AccountPatch {
@@ -23,6 +23,8 @@ pub trait AccountPatch {
 
 /// Mainnet account patch
 pub struct EmbeddedAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for EmbeddedAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
@@ -31,6 +33,8 @@ impl AccountPatch for EmbeddedAccountPatch {
 
 /// Mainnet account patch
 pub struct EmbeddedByzantiumAccountPatch;
+
+#[rustfmt::skip]
 impl AccountPatch for EmbeddedByzantiumAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::one() }
@@ -96,6 +100,7 @@ pub trait Patch {
 }
 
 /// Default precompiled collections.
+#[rustfmt::skip]
 pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -113,6 +118,8 @@ pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Pre
 
 /// Patch sepcific for the `jsontests` crate.
 pub struct VMTestPatch;
+
+#[rustfmt::skip]
 impl Patch for VMTestPatch {
     type Account = EmbeddedAccountPatch;
 
@@ -144,6 +151,8 @@ impl Patch for VMTestPatch {
 
 /// Embedded patch.
 pub struct EmbeddedPatch;
+
+#[rustfmt::skip]
 impl Patch for EmbeddedPatch {
     type Account = EmbeddedAccountPatch;
 
@@ -173,4 +182,3 @@ impl Patch for EmbeddedPatch {
         &EMBEDDED_PRECOMPILEDS
     }
 }
-

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -1,25 +1,29 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-#[cfg(not(feature = "std"))] use alloc::rc::Rc;
-#[cfg(feature = "std")] use std::rc::Rc;
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
+use std::rc::Rc;
 
 use bigint::Gas;
-#[cfg(all(feature = "std", any(feature = "rust-secp256k1", feature = "c-secp256k1")))] use std::cmp::min;
-#[cfg(all(not(feature = "std"), any(feature = "rust-secp256k1", feature = "c-secp256k1")))] use core::cmp::min;
+#[cfg(all(not(feature = "std"), any(feature = "rust-secp256k1", feature = "c-secp256k1")))]
+use core::cmp::min;
+#[cfg(all(feature = "std", any(feature = "rust-secp256k1", feature = "c-secp256k1")))]
+use std::cmp::min;
 
+use digest::{Digest, FixedOutput};
+use ripemd160::Ripemd160;
 use sha2::Sha256;
 #[cfg(any(feature = "rust-secp256k1", feature = "c-secp256k1"))]
 use sha3::Keccak256;
-use ripemd160::Ripemd160;
-use digest::{Digest, FixedOutput};
 
-#[cfg(feature = "c-secp256k1")]
-use secp256k1::{SECP256K1, RecoverableSignature, Message, RecoveryId, Error};
 #[cfg(feature = "rust-secp256k1")]
-use secp256k1::{recover, Message, RecoveryId, Signature, Error};
+use secp256k1::{recover, Error, Message, RecoveryId, Signature};
+#[cfg(feature = "c-secp256k1")]
+use secp256k1::{Error, Message, RecoverableSignature, RecoveryId, SECP256K1};
 
-use crate::errors::{RuntimeError, OnChainError};
+use crate::errors::{OnChainError, RuntimeError};
 
 /// Represent a precompiled contract.
 pub trait Precompiled: Sync {
@@ -46,8 +50,7 @@ pub trait Precompiled: Sync {
 pub struct IDPrecompiled;
 impl Precompiled for IDPrecompiled {
     fn gas(&self, data: &[u8]) -> Gas {
-        Gas::from(15u64) +
-            Gas::from(3u64) * gas_div_ceil(Gas::from(data.len()), Gas::from(32u64))
+        Gas::from(15u64) + Gas::from(3u64) * gas_div_ceil(Gas::from(data.len()), Gas::from(32u64))
     }
 
     fn step(&self, data: &[u8]) -> Rc<Vec<u8>> {
@@ -61,8 +64,7 @@ pub static ID_PRECOMPILED: IDPrecompiled = IDPrecompiled;
 pub struct RIP160Precompiled;
 impl Precompiled for RIP160Precompiled {
     fn gas(&self, data: &[u8]) -> Gas {
-        Gas::from(600u64) +
-            Gas::from(120u64) * gas_div_ceil(Gas::from(data.len()), Gas::from(32u64))
+        Gas::from(600u64) + Gas::from(120u64) * gas_div_ceil(Gas::from(data.len()), Gas::from(32u64))
     }
 
     fn step(&self, data: &[u8]) -> Rc<Vec<u8>> {
@@ -83,9 +85,7 @@ pub static RIP160_PRECOMPILED: RIP160Precompiled = RIP160Precompiled;
 pub struct SHA256Precompiled;
 impl Precompiled for SHA256Precompiled {
     fn gas(&self, data: &[u8]) -> Gas {
-        Gas::from(60u64) +
-            Gas::from(12u64) * gas_div_ceil(Gas::from(data.len()),
-                                            Gas::from(32u64))
+        Gas::from(60u64) + Gas::from(12u64) * gas_div_ceil(Gas::from(data.len()), Gas::from(32u64))
     }
 
     fn step(&self, data: &[u8]) -> Rc<Vec<u8>> {
@@ -120,7 +120,7 @@ impl Precompiled for ECRECPrecompiled {
                     *i = 0
                 }
                 Rc::new(ret.as_ref().into())
-            },
+            }
             Err(_) => Rc::new(Vec::new()),
         }
     }

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -4,13 +4,17 @@
 use alloc::vec::Vec;
 
 use bigint::M256;
-#[cfg(feature = "std")] use std::cmp::min;
-#[cfg(feature = "std")] use std::marker::PhantomData;
-#[cfg(not(feature = "std"))] use core::cmp::min;
-#[cfg(not(feature = "std"))] use core::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use core::cmp::min;
+#[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+#[cfg(feature = "std")]
+use std::cmp::min;
+#[cfg(feature = "std")]
+use std::marker::PhantomData;
 
-use super::Patch;
 use super::errors::OnChainError;
+use super::Patch;
 use crate::util::opcode::Opcode;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -18,14 +22,76 @@ use crate::util::opcode::Opcode;
 /// Instructions for the program counter. This is the same as `Opcode`
 /// except `PUSH`, which might take longer length.
 pub enum Instruction {
-    STOP, ADD, MUL, SUB, DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP,
-    SIGNEXTEND, LT, GT, SLT, SGT, EQ, ISZERO, AND, OR, XOR, NOT, BYTE,
-    SHL, SHR, SAR, SHA3, ADDRESS, BALANCE, ORIGIN, CALLER, CALLVALUE, CALLDATALOAD,
-    CALLDATASIZE, CALLDATACOPY, CODESIZE, CODECOPY, GASPRICE,
-    EXTCODESIZE, EXTCODECOPY, EXTCODEHASH, BLOCKHASH, COINBASE, TIMESTAMP, NUMBER,
-    DIFFICULTY, GASLIMIT, POP, MLOAD, MSTORE, MSTORE8, SLOAD, SSTORE,
-    JUMP, JUMPI, PC, MSIZE, GAS, JUMPDEST, CREATE, CREATE2, CALL, CALLCODE,
-    RETURN, DELEGATECALL, SUICIDE, STATICCALL, REVERT, RETURNDATASIZE, RETURNDATACOPY,
+    STOP,
+    ADD,
+    MUL,
+    SUB,
+    DIV,
+    SDIV,
+    MOD,
+    SMOD,
+    ADDMOD,
+    MULMOD,
+    EXP,
+    SIGNEXTEND,
+    LT,
+    GT,
+    SLT,
+    SGT,
+    EQ,
+    ISZERO,
+    AND,
+    OR,
+    XOR,
+    NOT,
+    BYTE,
+    SHL,
+    SHR,
+    SAR,
+    SHA3,
+    ADDRESS,
+    BALANCE,
+    ORIGIN,
+    CALLER,
+    CALLVALUE,
+    CALLDATALOAD,
+    CALLDATASIZE,
+    CALLDATACOPY,
+    CODESIZE,
+    CODECOPY,
+    GASPRICE,
+    EXTCODESIZE,
+    EXTCODECOPY,
+    EXTCODEHASH,
+    BLOCKHASH,
+    COINBASE,
+    TIMESTAMP,
+    NUMBER,
+    DIFFICULTY,
+    GASLIMIT,
+    POP,
+    MLOAD,
+    MSTORE,
+    MSTORE8,
+    SLOAD,
+    SSTORE,
+    JUMP,
+    JUMPI,
+    PC,
+    MSIZE,
+    GAS,
+    JUMPDEST,
+    CREATE,
+    CREATE2,
+    CALL,
+    CALLCODE,
+    RETURN,
+    DELEGATECALL,
+    SUICIDE,
+    STATICCALL,
+    REVERT,
+    RETURNDATASIZE,
+    RETURNDATACOPY,
 
     PUSH(M256),
     DUP(usize),
@@ -49,10 +115,10 @@ impl Valids {
                 Opcode::JUMPDEST => {
                     valids[i] = true;
                     i += 1;
-                },
+                }
                 Opcode::PUSH(v) => {
                     i += v + 1;
-                },
+                }
                 _ => {
                     i += 1;
                 }
@@ -65,11 +131,15 @@ impl Valids {
     /// Get the length of the valid mapping. This is the same as the
     /// code bytes.
     #[inline]
-    pub fn len(&self) -> usize { self.0.len() }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
     /// Returns true if the valids list is empty
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Returns `true` if the position is a valid jump destination. If
     /// not, returns `false`.
@@ -105,9 +175,7 @@ pub struct PCMut<'a, P: Patch> {
 macro_rules! impl_pc {
     ($t: tt) => {
         impl<'a, P: Patch> $t<'a, P> {
-            fn read_bytes(
-                &self, from_position: usize, byte_count: usize
-            ) -> Result<M256, OnChainError> {
+            fn read_bytes(&self, from_position: usize, byte_count: usize) -> Result<M256, OnChainError> {
                 if from_position > self.code.len() {
                     return Err(OnChainError::PCOverflow);
                 }
@@ -135,7 +203,7 @@ macro_rules! impl_pc {
                     match opcode {
                         Opcode::PUSH(v) => {
                             i += v + 1;
-                        },
+                        }
                         _ => {
                             i += 1;
                         }
@@ -200,21 +268,21 @@ macro_rules! impl_pc {
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::SHR => {
                         if P::has_bitwise_shift() {
                             Instruction::SHR
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::SAR => {
                         if P::has_bitwise_shift() {
                             Instruction::SAR
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
 
                     Opcode::SHA3 => Instruction::SHA3,
 
@@ -256,7 +324,7 @@ macro_rules! impl_pc {
                     Opcode::PUSH(v) => {
                         let param = self.read_bytes(*self.position + 1, v)?;
                         Instruction::PUSH(param)
-                    },
+                    }
 
                     Opcode::DUP(v) => Instruction::DUP(v),
                     Opcode::SWAP(v) => Instruction::SWAP(v),
@@ -269,7 +337,7 @@ macro_rules! impl_pc {
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::CALL => Instruction::CALL,
                     Opcode::CALLCODE => Instruction::CALLCODE,
                     Opcode::RETURN => Instruction::RETURN,
@@ -279,44 +347,44 @@ macro_rules! impl_pc {
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::STATICCALL => {
                         if P::has_static_call() {
                             Instruction::STATICCALL
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::REVERT => {
                         if P::has_revert() {
                             Instruction::REVERT
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::RETURNDATASIZE => {
                         if P::has_return_data() {
                             Instruction::RETURNDATASIZE
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
                     Opcode::RETURNDATACOPY => {
                         if P::has_return_data() {
                             Instruction::RETURNDATACOPY
                         } else {
                             return Err(OnChainError::InvalidOpcode);
                         }
-                    },
+                    }
 
                     Opcode::INVALID => {
                         return Err(OnChainError::InvalidOpcode);
-                    },
+                    }
                     Opcode::SUICIDE => Instruction::SUICIDE,
                 })
             }
         }
-    }
+    };
 }
 
 impl_pc!(PC);
@@ -326,7 +394,9 @@ impl<'a, P: Patch> PC<'a, P> {
     /// Create a new program counter from the given code.
     pub fn new(code: &'a [u8], valids: &'a Valids, position: &'a usize) -> Self {
         Self {
-            code, valids, position,
+            code,
+            valids,
+            position,
             _patch: PhantomData,
         }
     }
@@ -336,7 +406,9 @@ impl<'a, P: Patch> PCMut<'a, P> {
     /// Create a new program counter from the given code.
     pub fn new(code: &'a [u8], valids: &'a Valids, position: &'a mut usize) -> Self {
         Self {
-            code, valids, position,
+            code,
+            valids,
+            position,
             _patch: PhantomData,
         }
     }
@@ -363,10 +435,10 @@ impl<'a, P: Patch> PCMut<'a, P> {
         match opcode {
             Opcode::PUSH(v) => {
                 *self.position = min(*self.position + v + 1, self.code.len());
-            },
+            }
             _ => {
                 *self.position += 1;
-            },
+            }
         }
         Ok(result)
     }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -3,8 +3,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use bigint::M256;
 use super::errors::OnChainError;
+use bigint::M256;
 
 /// Represents an EVM stack.
 #[derive(Debug)]
@@ -14,9 +14,7 @@ pub struct Stack {
 
 impl Default for Stack {
     fn default() -> Stack {
-        Stack {
-            stack: Vec::new(),
-        }
+        Stack { stack: Vec::new() }
     }
 }
 
@@ -84,5 +82,7 @@ impl Stack {
 
     /// Returns true if stack is empty
     #[inline]
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/src/util/opcode.rs
+++ b/src/util/opcode.rs
@@ -4,32 +4,90 @@
 #[allow(missing_docs)]
 /// Opcode enum. One-to-one corresponding to an `u8` value.
 pub enum Opcode {
-    STOP, ADD, MUL, SUB, DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP,
+    STOP,
+    ADD,
+    MUL,
+    SUB,
+    DIV,
+    SDIV,
+    MOD,
+    SMOD,
+    ADDMOD,
+    MULMOD,
+    EXP,
     SIGNEXTEND,
 
-    LT, GT, SLT, SGT, EQ, ISZERO, AND, OR, XOR, NOT, BYTE,
+    LT,
+    GT,
+    SLT,
+    SGT,
+    EQ,
+    ISZERO,
+    AND,
+    OR,
+    XOR,
+    NOT,
+    BYTE,
 
-    SHL, SHR, SAR,
+    SHL,
+    SHR,
+    SAR,
 
     SHA3,
 
-    ADDRESS, BALANCE, ORIGIN, CALLER, CALLVALUE, CALLDATALOAD,
-    CALLDATASIZE, CALLDATACOPY, CODESIZE, CODECOPY, GASPRICE,
-    EXTCODESIZE, EXTCODECOPY, EXTCODEHASH, RETURNDATASIZE, RETURNDATACOPY,
+    ADDRESS,
+    BALANCE,
+    ORIGIN,
+    CALLER,
+    CALLVALUE,
+    CALLDATALOAD,
+    CALLDATASIZE,
+    CALLDATACOPY,
+    CODESIZE,
+    CODECOPY,
+    GASPRICE,
+    EXTCODESIZE,
+    EXTCODECOPY,
+    EXTCODEHASH,
+    RETURNDATASIZE,
+    RETURNDATACOPY,
 
-    BLOCKHASH, COINBASE, TIMESTAMP, NUMBER, DIFFICULTY, GASLIMIT,
+    BLOCKHASH,
+    COINBASE,
+    TIMESTAMP,
+    NUMBER,
+    DIFFICULTY,
+    GASLIMIT,
 
-    POP, MLOAD, MSTORE, MSTORE8, SLOAD, SSTORE, JUMP, JUMPI, PC,
-    MSIZE, GAS, JUMPDEST,
+    POP,
+    MLOAD,
+    MSTORE,
+    MSTORE8,
+    SLOAD,
+    SSTORE,
+    JUMP,
+    JUMPI,
+    PC,
+    MSIZE,
+    GAS,
+    JUMPDEST,
 
     PUSH(usize),
     DUP(usize),
     SWAP(usize),
     LOG(usize),
 
-    CREATE, CREATE2, CALL, CALLCODE, RETURN, DELEGATECALL, STATICCALL, REVERT,
+    CREATE,
+    CREATE2,
+    CALL,
+    CALLCODE,
+    RETURN,
+    DELEGATECALL,
+    STATICCALL,
+    REVERT,
 
-    INVALID, SUICIDE
+    INVALID,
+    SUICIDE,
 }
 
 impl From<u8> for Opcode {
@@ -265,22 +323,22 @@ impl Into<u8> for Opcode {
             Opcode::PUSH(v) => {
                 assert!(v >= 1 && v <= 32);
                 0x5f + (v as u8)
-            },
+            }
 
             Opcode::DUP(v) => {
                 assert!(v >= 1 && v <= 16);
                 0x7f + (v as u8)
-            },
+            }
 
             Opcode::SWAP(v) => {
                 assert!(v >= 1 && v <= 16);
                 0x8f + (v as u8)
-            },
+            }
 
             Opcode::LOG(v) => {
                 assert!(v <= 4);
                 0xa0 + (v as u8)
-            },
+            }
 
             Opcode::CREATE => 0xf0,
             Opcode::CALL => 0xf1,


### PR DESCRIPTION
This PR applies global formatting rules (described in `rustfmt.toml`) to the codebase.

WIth the CI stage checking the formatting for correctness, this is the first step to enforsing the common formatting style in the repo.

Closes #30 

This is not a breaking change, though it would require applying the formatting for those branches created from unformatted master base before the merge.

In my opinion the easiest way to go with these branches is to copy the `rustfmt.toml` from master, run `cargo fmt` and then make a `master->branch` merge instead of the rebase to minimize git conflicts.