### PR TITLE
Refactor external declaration manager

### DIFF
--- a/src/evmjit/compiler/runtime/mod.rs
+++ b/src/evmjit/compiler/runtime/mod.rs
@@ -134,11 +134,7 @@ impl MainPrologue {
         let types_instance = EvmTypes::get_instance(context);
         let phi = temp_builder.build_phi(types_instance.get_contract_return_type(), "ret");
 
-        let free_func = if let Some(func) = decl_factory.get_decl("free") {
-            func
-        } else {
-            decl_factory.add_decl(FreeDecl::new(context)) 
-        };
+        let free_func = decl_factory.get_decl(FreeDecl::new(context));
 
         temp_builder.build_call(free_func, &[stack_base.into()], "");
         let index = Gas.to_index() as u32;

--- a/src/evmjit/compiler/runtime/stack_init.rs
+++ b/src/evmjit/compiler/runtime/stack_init.rs
@@ -19,11 +19,7 @@ impl StackAllocator {
     pub fn new(context: &Context, builder: &Builder, decl_factory: &ExternalFunctionManager) -> StackAllocator {
         let types_instance = EvmTypes::get_instance(context);
 
-        let malloc_func = if let Some(func) = decl_factory.get_decl("malloc") {
-            func
-        } else {
-            decl_factory.add_decl(MallocDecl::new(context))
-        };
+        let malloc_func = decl_factory.get_decl(MallocDecl::new(context)); 
         
         let malloc_size = (types_instance.get_word_type().get_bit_width() / 8) * EVM_MAX_STACK_SIZE;
         let malloc_size_ir_value = context.i64_type().const_int (malloc_size as u64, false);


### PR DESCRIPTION
Insertion of declarations is now manual.
`get_decl` takes a string, rather than a hardcoded method, and can cache/manage arbitrary function declarations.
Tests seem to be failing. They are also failing on `etcjit`.